### PR TITLE
build: do not use `package-name` input in release-please

### DIFF
--- a/.github/workflows/release-please.yml
+++ b/.github/workflows/release-please.yml
@@ -16,4 +16,3 @@ jobs:
       - uses: google-github-actions/release-please-action@v3
         with:
           release-type: rust
-          package-name: release-please-action


### PR DESCRIPTION
Was failing after bumping to v4:

```
Unexpected input(s) 'package-name', valid inputs are ['token', 'release-type', 'path', 'target-branch', 'config-file', 'manifest-file', 'repo-url', 'github-api-url', 'github-graphql-url', 'fork', 'include-component-in-tag', 'proxy-server', 'skip-github-release', 'skip-github-pull-request', 'changelog-host']
```
