### PR TITLE
feat(edit): allow editing thoughts

### DIFF
--- a/src/model/thoughts.rs
+++ b/src/model/thoughts.rs
@@ -330,7 +330,7 @@ pub struct Error {
 
 impl std::fmt::Display for Error {
     fn fmt(&self, f: &mut Formatter) -> std::fmt::Result {
-        write!(f, "SQLite store error: {}", self.message)
+        write!(f, "Thought error: {}", self.message)
     }
 }
 


### PR DESCRIPTION
In addition to changing dates, allow changing thoughts as well, including adding and dropping entity references. Removing entity reference does not remove an entity even if no references remain in all thoughts.
