### PR TITLE
CI: Configure Codecov to ignore main.rs

### DIFF
--- a/codecov.yml
+++ b/codecov.yml
@@ -1,0 +1,29 @@
+codecov:
+  require_ci_to_pass: true
+
+coverage:
+  precision: 2
+  round: down
+  range: "70...100"
+  status:
+    project:
+      default:
+        # basic settings
+        target: auto
+        threshold: 1%
+        base: auto
+        # advanced settings
+        branches: null
+        if_ci_failed: error
+        informational: false
+        only_pulls: false
+
+ignore:
+  - "src/main.rs"  # Ignore the main.rs file as it's mainly CLI glue code
+
+comment:
+  layout: "reach,diff,flags,files,footer"
+  behavior: default
+  require_changes: false
+  require_base: false
+  require_head: true


### PR DESCRIPTION
This PR adds configuration to exclude src/main.rs from Codecov coverage reports.

## Changes
- Add a codecov.yml configuration file that excludes src/main.rs from coverage reports

## Rationale
The main.rs file primarily contains CLI glue code rather than core business logic, and it's challenging to unit test effectively as it deals with external interaction. Excluding it from coverage metrics will provide a more representative view of test coverage for the core application code.

This change will make the coverage metrics more meaningful by focusing on the parts of the codebase that should have high test coverage.

🤖 Generated with [Claude Code](https://claude.ai/code)