### PR TITLE
feat: XDG data directory for storage and config

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -47,3 +47,4 @@ Thumbs.db
 *.profdata
 tarpaulin-report.html
 cobertura.xml
+lcov.info

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -46,12 +46,15 @@ Domain model must not depend on CLI or persistence. Persistence is behind reposi
 
 - clap 4.6 (CLI), rusqlite 0.39 (SQLite), chrono 0.4 (dates), regex 1.12 (entity parsing)
 - thiserror 2.0 (error types), owo-colors 4 (terminal styling), terminal_size 0.4 (TTY detection)
-- tempfile 3.27 (editor temp files)
+- tempfile 3.27 (editor temp files), dirs 6.0 (XDG data directory), serde 1 + toml 0.8 (config)
 - ratatui 0.30 + crossterm (TUI framework), tui-input 0.15 (text input), nucleo-matcher 0.3 (fuzzy search)
 
-## Database
+## Data Directory
 
-- SQLite at `~/.local/share/wetware/thoughts.db` (or `WETWARE_DB` env var)
+- Data directory at `~/.local/share/wetware/` (XDG data dir), overridable via `WETWARE_DATA_DIR` env var
+- Contains `config.toml` (TOML config) and `default.db` (SQLite database)
+- Database path overridable via `WETWARE_DB` env var (takes precedence over data dir for db)
+- **Debug builds panic if `WETWARE_DATA_DIR` is not set** — prevents dev/test from touching production data
 - Tables: `thoughts`, `entities` (with `description` column), `thought_entities` (junction)
 - Migrations in `src/storage/migrations/`
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -408,6 +408,27 @@ dependencies = [
 ]
 
 [[package]]
+name = "dirs"
+version = "6.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c3e8aa94d75141228480295a7d0e7feb620b1a5ad9f12bc40be62411e38cce4e"
+dependencies = [
+ "dirs-sys",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e01a3366d27ee9890022452ee61b2b63a67e6f13f58900b651ff5665f0bb1fab"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys",
+]
+
+[[package]]
 name = "document-features"
 version = "0.2.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -530,6 +551,17 @@ checksum = "85649ca51fd72272d7821adaf274ad91c288277713d9c18820d8499a7ff69e9a"
 dependencies = [
  "typenum",
  "version_check",
+]
+
+[[package]]
+name = "getrandom"
+version = "0.2.17"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ff2abc00be7fca6ebc474524697ae276ad847ad0a6b3faa4bcb027e9a4614ad0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "wasi",
 ]
 
 [[package]]
@@ -758,6 +790,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
+name = "libredox"
+version = "0.1.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e02f3bb43d335493c96bf3fd3a321600bf6bd07ed34bc64118e9293bdffea46c"
+dependencies = [
+ "libc",
+]
+
+[[package]]
 name = "libsqlite3-sys"
 version = "0.37.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -941,6 +982,12 @@ name = "once_cell_polyfill"
 version = "1.70.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "384b8ab6d37215f3c5301a95a4accb5d64aa607f1fcb26a11b5303878451b4fe"
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "ordered-float"
@@ -1247,6 +1294,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "redox_users"
+version = "0.5.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a4e608c6638b9c18977b00b475ac1f28d14e84b27d8d42f70e0bf1e3dec127ac"
+dependencies = [
+ "getrandom 0.2.17",
+ "libredox",
+ "thiserror 2.0.18",
+]
+
+[[package]]
 name = "regex"
 version = "1.12.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1387,6 +1445,15 @@ dependencies = [
  "serde",
  "serde_core",
  "zmij",
+]
+
+[[package]]
+name = "serde_spanned"
+version = "0.6.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bf41e0cfaf7226dca15e8197172c295a782857fcb97fad1808a166870dee75a3"
+dependencies = [
+ "serde",
 ]
 
 [[package]]
@@ -1683,6 +1750,47 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7694e1cfe791f8d31026952abf09c69ca6f6fa4e1a1229e18988f06a04a12dca"
 
 [[package]]
+name = "toml"
+version = "0.8.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dc1beb996b9d83529a9e75c17a1686767d148d70663143c7854d8b4a09ced362"
+dependencies = [
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_edit",
+]
+
+[[package]]
+name = "toml_datetime"
+version = "0.6.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "22cddaf88f4fbc13c51aebbf5f8eceb5c7c5a9da2ac40a13519eb5b0a0e8f11c"
+dependencies = [
+ "serde",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.27"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "41fe8c660ae4257887cf66394862d21dbca4a6ddd26f04a3560410406a2f819a"
+dependencies = [
+ "indexmap",
+ "serde",
+ "serde_spanned",
+ "toml_datetime",
+ "toml_write",
+ "winnow",
+]
+
+[[package]]
+name = "toml_write"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5d99f8c9a7727884afe522e9bd5edbfc91a3312b36a77b5fb8926e4c31a41801"
+
+[[package]]
 name = "tui-input"
 version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1887,14 +1995,17 @@ version = "1.0.0"
 dependencies = [
  "chrono",
  "clap",
+ "dirs",
  "nucleo-matcher",
  "owo-colors",
  "ratatui",
  "regex",
  "rusqlite",
+ "serde",
  "tempfile",
  "terminal_size",
  "thiserror 2.0.18",
+ "toml",
  "tui-input",
 ]
 
@@ -2058,6 +2169,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ae137229bcbd6cdf0f7b80a31df61766145077ddf49416a728b02cb3921ff3fc"
 dependencies = [
  "windows-link",
+]
+
+[[package]]
+name = "winnow"
+version = "0.7.15"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "df79d97927682d2fd8adb29682d1140b343be4ac0f08fd68b7765d9c059d3945"
+dependencies = [
+ "memchr",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,6 +18,9 @@ thiserror = "2.0"
 owo-colors = { version = "4", features = ["supports-colors"] }
 terminal_size = "0.4"
 tempfile = "3.27"
+dirs = "6.0"
+serde = { version = "1", features = ["derive"] }
+toml = "0.8"
 ratatui = "0.30"
 tui-input = "0.15"
 nucleo-matcher = "0.3"

--- a/specs/007-data-directory.md
+++ b/specs/007-data-directory.md
@@ -1,0 +1,51 @@
+# 007: Data Directory
+
+## Summary
+
+Wetware uses a dedicated data directory following XDG conventions (`~/.local/share/wetware/`) to store its database and configuration. The directory is auto-created on first run. Debug builds require an explicit override, ensuring development and testing never touch the user's production data.
+
+## Requirements
+
+- Default data directory is `$XDG_DATA_HOME/wetware/` (typically `~/.local/share/wetware/`)
+- On first run, the directory is created automatically if it doesn't exist
+- Directory contains a TOML config file (`config.toml`) and a default database (`default.db`)
+- `WETWARE_DATA_DIR` env var overrides the entire data directory location
+- `WETWARE_DB` env var overrides just the database path (takes precedence over data dir for db)
+- Debug builds (`cargo build`/`cargo run`/`cargo test`) panic if no explicit data dir override is set — they never resolve the real XDG path
+- Only release builds resolve the real XDG data directory
+- Config file uses TOML format with serde for (de)serialization
+- Config file is created with sensible defaults on first run if missing
+
+## Decisions
+
+- **XDG via `dirs` crate**: `dirs::data_dir()` for cross-platform data directory resolution. Only called in release builds.
+- **Compile-time guard**: `#[cfg(debug_assertions)]` prevents debug builds from ever computing the real data dir. Developers must set `WETWARE_DATA_DIR` explicitly.
+- **TOML config**: idiomatic for Rust, human-readable, uses `toml` + `serde` crates.
+- **Single default database**: `default.db` in the data directory. Structure allows future multi-database support.
+- **Env var precedence**: `WETWARE_DB` > `<data_dir>/default.db`; `WETWARE_DATA_DIR` > XDG default.
+
+## Directory Structure
+
+```
+~/.local/share/wetware/
+├── config.toml          # User preferences and settings
+└── default.db           # Default SQLite database
+```
+
+## CLI Interface
+
+No new commands. Existing commands transparently use the data directory:
+
+```
+wet add "thought"            # Uses ~/.local/share/wetware/default.db
+WETWARE_DATA_DIR=/tmp/w wet add "thought"   # Uses /tmp/w/default.db
+WETWARE_DB=/tmp/t.db wet add "thought"      # Uses /tmp/t.db directly
+```
+
+## Edge Cases
+
+- `dirs::data_dir()` returns `None` (e.g., `$HOME` not set) → clear error message
+- Data directory exists but is not writable → standard IO error propagation
+- Config file exists but is malformed → error with details, not silent fallback
+- `WETWARE_DB` set alongside `WETWARE_DATA_DIR` → `WETWARE_DB` wins for database path
+- Debug build without `WETWARE_DATA_DIR` → panic with message explaining the requirement

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -11,7 +11,7 @@ use chrono::NaiveDate;
 use std::path::Path;
 
 /// Execute the add command
-pub fn execute(content: String, date: Option<String>, db_path: Option<&Path>) -> Result<(), ThoughtError> {
+pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
     // Create and validate thought
     let thought = if let Some(ref date_str) = date {
         let naive = NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -27,7 +27,7 @@ pub fn execute(
     content: Option<String>,
     date: Option<String>,
     use_editor: bool,
-    db_path: Option<&Path>,
+    db_path: &Path,
 ) -> Result<(), ThoughtError> {
     // Validate at least one edit argument was provided
     if content.is_none() && date.is_none() && !use_editor {

--- a/src/cli/entities.rs
+++ b/src/cli/entities.rs
@@ -30,7 +30,7 @@ use std::path::Path;
 /// entity-name
 /// entity-without-description
 /// ```
-pub fn execute(db_path: Option<&Path>) -> Result<(), ThoughtError> {
+pub fn execute(db_path: &Path) -> Result<(), ThoughtError> {
     // Get database connection
     let conn = get_connection(db_path)?;
 

--- a/src/cli/entity_edit.rs
+++ b/src/cli/entity_edit.rs
@@ -29,7 +29,7 @@ pub fn execute(
     entity_name: &str,
     description: Option<String>,
     description_file: Option<PathBuf>,
-    db_path: Option<&Path>,
+    db_path: &Path,
 ) -> Result<(), ThoughtError> {
     // T031: Check mutual exclusivity of input methods (both flags cannot be used together)
     if description.is_some() && description_file.is_some() {

--- a/src/cli/thoughts.rs
+++ b/src/cli/thoughts.rs
@@ -14,7 +14,7 @@ use std::path::Path;
 /// * `db_path` - Optional path to the database file
 /// * `entity_filter` - Optional entity name to filter thoughts by
 /// * `color_mode` - Controls whether output should be styled with colors
-pub fn execute(db_path: Option<&Path>, entity_filter: Option<&str>, color_mode: ColorMode) -> Result<(), ThoughtError> {
+pub fn execute(db_path: &Path, entity_filter: Option<&str>, color_mode: ColorMode) -> Result<(), ThoughtError> {
     // Get database connection
     let conn = get_connection(db_path)?;
 

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -15,7 +15,7 @@ use crate::tui::App;
 ///
 /// Opens the database, loads all thoughts and entities, initializes a full-screen
 /// terminal, and runs the TUI event loop. Terminal state is restored on exit.
-pub fn execute(db_path: Option<&Path>) -> Result<(), ThoughtError> {
+pub fn execute(db_path: &Path) -> Result<(), ThoughtError> {
     let conn = get_connection(db_path)?;
     let thoughts = ThoughtsRepository::list_all(&conn)?;
     let entities = EntitiesRepository::list_all(&conn)?;

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,0 +1,118 @@
+/// Configuration file management
+use crate::errors::ThoughtError;
+use serde::{Deserialize, Serialize};
+use std::path::Path;
+
+/// Wetware configuration
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct Config {
+    /// Configuration format version for future migrations
+    pub version: u32,
+}
+
+impl Default for Config {
+    fn default() -> Self {
+        Self { version: 1 }
+    }
+}
+
+const CONFIG_FILENAME: &str = "config.toml";
+
+/// Load configuration from the data directory.
+///
+/// Returns default config if the file doesn't exist.
+/// Returns an error if the file exists but is malformed.
+pub fn load_config(data_dir: &Path) -> Result<Config, ThoughtError> {
+    let config_path = data_dir.join(CONFIG_FILENAME);
+
+    if !config_path.exists() {
+        return Ok(Config::default());
+    }
+
+    let contents = std::fs::read_to_string(&config_path)?;
+    toml::from_str(&contents).map_err(|e| ThoughtError::InvalidInput(format!("Malformed config file: {e}")))
+}
+
+/// Save configuration to the data directory.
+pub fn save_config(data_dir: &Path, config: &Config) -> Result<(), ThoughtError> {
+    let config_path = data_dir.join(CONFIG_FILENAME);
+    let contents =
+        toml::to_string_pretty(config).map_err(|e| ThoughtError::InvalidInput(format!("Failed to serialize config: {e}")))?;
+    std::fs::write(&config_path, contents)?;
+    Ok(())
+}
+
+/// Ensure a config file exists in the data directory, creating a default one if missing.
+pub fn ensure_config(data_dir: &Path) -> Result<Config, ThoughtError> {
+    let config = load_config(data_dir)?;
+    let config_path = data_dir.join(CONFIG_FILENAME);
+    if !config_path.exists() {
+        save_config(data_dir, &config)?;
+    }
+    Ok(config)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_default_config() {
+        let config = Config::default();
+        assert_eq!(config.version, 1);
+    }
+
+    #[test]
+    fn test_load_config_missing_file_returns_default() {
+        let temp = TempDir::new().unwrap();
+        let config = load_config(temp.path()).unwrap();
+        assert_eq!(config, Config::default());
+    }
+
+    #[test]
+    fn test_save_and_load_config() {
+        let temp = TempDir::new().unwrap();
+        let config = Config { version: 2 };
+        save_config(temp.path(), &config).unwrap();
+        let loaded = load_config(temp.path()).unwrap();
+        assert_eq!(loaded, config);
+    }
+
+    #[test]
+    fn test_load_malformed_config_errors() {
+        let temp = TempDir::new().unwrap();
+        std::fs::write(temp.path().join("config.toml"), "not valid toml [[[").unwrap();
+        let result = load_config(temp.path());
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Malformed config file"));
+    }
+
+    #[test]
+    fn test_ensure_config_creates_file() {
+        let temp = TempDir::new().unwrap();
+        let config_path = temp.path().join("config.toml");
+        assert!(!config_path.exists());
+        let config = ensure_config(temp.path()).unwrap();
+        assert_eq!(config, Config::default());
+        assert!(config_path.exists());
+    }
+
+    #[test]
+    fn test_ensure_config_preserves_existing() {
+        let temp = TempDir::new().unwrap();
+        let custom = Config { version: 5 };
+        save_config(temp.path(), &custom).unwrap();
+        let config = ensure_config(temp.path()).unwrap();
+        assert_eq!(config, custom);
+    }
+
+    #[test]
+    fn test_config_roundtrip_toml() {
+        let config = Config::default();
+        let serialized = toml::to_string_pretty(&config).unwrap();
+        let deserialized: Config = toml::from_str(&serialized).unwrap();
+        assert_eq!(config, deserialized);
+    }
+}

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,5 +1,6 @@
 /// Wetware - Personal networked note-taking system
 pub mod cli;
+pub mod config;
 pub mod errors;
 pub mod input;
 pub mod models;

--- a/src/main.rs
+++ b/src/main.rs
@@ -10,7 +10,10 @@ fn main() {
     let cli = Cli::parse();
 
     // Resolve data directory: WETWARE_DATA_DIR env var > XDG default (release only)
-    let data_dir_override = env::var("WETWARE_DATA_DIR").ok().map(PathBuf::from);
+    let data_dir_override = env::var("WETWARE_DATA_DIR")
+        .ok()
+        .filter(|v| !v.is_empty())
+        .map(PathBuf::from);
     let data_dir = match resolve_data_dir(data_dir_override.as_deref()) {
         Ok(dir) => dir,
         Err(e) => {
@@ -32,27 +35,27 @@ fn main() {
     // Database path: WETWARE_DB env var > <data_dir>/default.db
     let db_path = env::var("WETWARE_DB")
         .ok()
+        .filter(|v| !v.is_empty())
         .map(PathBuf::from)
         .unwrap_or_else(|| default_db_path_in(&data_dir));
-    let db_path = Some(db_path);
 
     let result = match cli.command {
-        Commands::Tui => wetware::cli::tui::execute(db_path.as_deref()),
-        Commands::Add { content, date } => wetware::cli::add::execute(content, date, db_path.as_deref()),
+        Commands::Tui => wetware::cli::tui::execute(&db_path),
+        Commands::Add { content, date } => wetware::cli::add::execute(content, date, &db_path),
         Commands::Edit {
             id,
             content,
             date,
             editor,
-        } => wetware::cli::edit::execute(id, content, date, editor, db_path.as_deref()),
-        Commands::Thoughts { on } => wetware::cli::thoughts::execute(db_path.as_deref(), on.as_deref(), cli.color),
-        Commands::Entities => wetware::cli::entities::execute(db_path.as_deref()),
+        } => wetware::cli::edit::execute(id, content, date, editor, &db_path),
+        Commands::Thoughts { on } => wetware::cli::thoughts::execute(&db_path, on.as_deref(), cli.color),
+        Commands::Entities => wetware::cli::entities::execute(&db_path),
         Commands::Entity { command } => match command {
             EntityCommands::Edit {
                 entity_name,
                 description,
                 description_file,
-            } => wetware::cli::entity_edit::execute(&entity_name, description, description_file, db_path.as_deref()),
+            } => wetware::cli::entity_edit::execute(&entity_name, description, description_file, &db_path),
         },
     };
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,12 +3,38 @@ use std::env;
 use std::path::PathBuf;
 use std::process;
 use wetware::cli::{Cli, Commands, EntityCommands};
+use wetware::config;
+use wetware::storage::{default_db_path_in, ensure_data_dir, resolve_data_dir};
 
 fn main() {
     let cli = Cli::parse();
 
-    // Get database path from environment variable or use default
-    let db_path = env::var("WETWARE_DB").ok().map(PathBuf::from);
+    // Resolve data directory: WETWARE_DATA_DIR env var > XDG default (release only)
+    let data_dir_override = env::var("WETWARE_DATA_DIR").ok().map(PathBuf::from);
+    let data_dir = match resolve_data_dir(data_dir_override.as_deref()) {
+        Ok(dir) => dir,
+        Err(e) => {
+            eprintln!("Error: {e}");
+            process::exit(1);
+        }
+    };
+
+    // Ensure data directory exists and config is initialized
+    if let Err(e) = ensure_data_dir(&data_dir) {
+        eprintln!("Error creating data directory: {e}");
+        process::exit(1);
+    }
+    if let Err(e) = config::ensure_config(&data_dir) {
+        eprintln!("Error initializing config: {e}");
+        process::exit(1);
+    }
+
+    // Database path: WETWARE_DB env var > <data_dir>/default.db
+    let db_path = env::var("WETWARE_DB")
+        .ok()
+        .map(PathBuf::from)
+        .unwrap_or_else(|| default_db_path_in(&data_dir));
+    let db_path = Some(db_path);
 
     let result = match cli.command {
         Commands::Tui => wetware::cli::tui::execute(db_path.as_deref()),

--- a/src/storage/connection.rs
+++ b/src/storage/connection.rs
@@ -5,10 +5,9 @@ use std::path::Path;
 
 /// Get a database connection
 ///
-/// A database path must be provided. Creates the database file if it doesn't exist.
-pub fn get_connection(db_path: Option<&Path>) -> Result<Connection, ThoughtError> {
-    let path = db_path.expect("database path must be provided — use resolve_data_dir() to determine it");
-    let conn = Connection::open(path)?;
+/// Creates the database file if it doesn't exist.
+pub fn get_connection(db_path: &Path) -> Result<Connection, ThoughtError> {
+    let conn = Connection::open(db_path)?;
 
     // Enable foreign key constraints
     conn.execute("PRAGMA foreign_keys = ON", [])?;
@@ -43,7 +42,7 @@ mod tests {
 
         assert!(!db_path.exists());
 
-        let _conn = get_connection(Some(&db_path)).unwrap();
+        let _conn = get_connection(&db_path).unwrap();
 
         assert!(db_path.exists());
     }
@@ -52,7 +51,7 @@ mod tests {
     fn test_get_connection_foreign_keys_enabled() {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
-        let conn = get_connection(Some(&db_path)).unwrap();
+        let conn = get_connection(&db_path).unwrap();
 
         let fk_enabled: i32 = conn.query_row("PRAGMA foreign_keys", [], |row| row.get(0)).unwrap();
         assert_eq!(fk_enabled, 1);

--- a/src/storage/connection.rs
+++ b/src/storage/connection.rs
@@ -1,19 +1,13 @@
 /// Database connection management
 use crate::errors::ThoughtError;
 use rusqlite::Connection;
-use std::path::{Path, PathBuf};
-
-/// Get the default database path
-pub fn default_db_path() -> PathBuf {
-    PathBuf::from("wetware.db")
-}
+use std::path::Path;
 
 /// Get a database connection
 ///
-/// Creates the database file if it doesn't exist.
+/// A database path must be provided. Creates the database file if it doesn't exist.
 pub fn get_connection(db_path: Option<&Path>) -> Result<Connection, ThoughtError> {
-    let default_path = default_db_path();
-    let path = db_path.unwrap_or(&default_path);
+    let path = db_path.expect("database path must be provided — use resolve_data_dir() to determine it");
     let conn = Connection::open(path)?;
 
     // Enable foreign key constraints

--- a/src/storage/data_dir.rs
+++ b/src/storage/data_dir.rs
@@ -17,7 +17,7 @@ pub fn resolve_data_dir(override_path: Option<&Path>) -> Result<PathBuf, Thought
     {
         panic!(
             "debug builds require an explicit data directory override \
-             (set WETWARE_DATA_DIR or pass --data-dir). \
+             (set WETWARE_DATA_DIR). \
              This prevents accidentally touching production data."
         );
     }
@@ -58,10 +58,18 @@ mod tests {
         assert_eq!(result, temp.path());
     }
 
+    #[cfg(debug_assertions)]
     #[test]
     #[should_panic(expected = "debug builds require an explicit data directory override")]
     fn test_resolve_data_dir_panics_in_debug_without_override() {
         let _ = resolve_data_dir(None);
+    }
+
+    #[cfg(not(debug_assertions))]
+    #[test]
+    fn test_resolve_data_dir_without_override_does_not_panic_in_release() {
+        let result = std::panic::catch_unwind(|| resolve_data_dir(None));
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/storage/data_dir.rs
+++ b/src/storage/data_dir.rs
@@ -1,0 +1,89 @@
+/// Data directory resolution and initialization
+use crate::errors::ThoughtError;
+use std::path::{Path, PathBuf};
+
+/// Resolve the wetware data directory.
+///
+/// If `override_path` is provided, uses that directly.
+/// In release builds, falls back to `dirs::data_dir()/wetware`.
+/// In debug builds, panics if no override is provided — this prevents
+/// development and testing from ever touching the user's production data.
+pub fn resolve_data_dir(override_path: Option<&Path>) -> Result<PathBuf, ThoughtError> {
+    if let Some(path) = override_path {
+        return Ok(path.to_path_buf());
+    }
+
+    #[cfg(debug_assertions)]
+    {
+        panic!(
+            "debug builds require an explicit data directory override \
+             (set WETWARE_DATA_DIR or pass --data-dir). \
+             This prevents accidentally touching production data."
+        );
+    }
+
+    #[cfg(not(debug_assertions))]
+    {
+        dirs::data_dir()
+            .map(|d| d.join("wetware"))
+            .ok_or_else(|| {
+                ThoughtError::InvalidInput(
+                    "Could not determine data directory: $HOME or platform equivalent is not set"
+                        .to_string(),
+                )
+            })
+    }
+}
+
+/// Ensure the data directory exists, creating it if necessary.
+pub fn ensure_data_dir(path: &Path) -> Result<(), ThoughtError> {
+    std::fs::create_dir_all(path)?;
+    Ok(())
+}
+
+/// Get the default database path within a data directory.
+pub fn default_db_path_in(data_dir: &Path) -> PathBuf {
+    data_dir.join("default.db")
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use tempfile::TempDir;
+
+    #[test]
+    fn test_resolve_data_dir_with_override() {
+        let temp = TempDir::new().unwrap();
+        let result = resolve_data_dir(Some(temp.path())).unwrap();
+        assert_eq!(result, temp.path());
+    }
+
+    #[test]
+    #[should_panic(expected = "debug builds require an explicit data directory override")]
+    fn test_resolve_data_dir_panics_in_debug_without_override() {
+        let _ = resolve_data_dir(None);
+    }
+
+    #[test]
+    fn test_ensure_data_dir_creates_directory() {
+        let temp = TempDir::new().unwrap();
+        let nested = temp.path().join("a").join("b").join("c");
+        assert!(!nested.exists());
+        ensure_data_dir(&nested).unwrap();
+        assert!(nested.exists());
+        assert!(nested.is_dir());
+    }
+
+    #[test]
+    fn test_ensure_data_dir_existing_directory() {
+        let temp = TempDir::new().unwrap();
+        ensure_data_dir(temp.path()).unwrap();
+        assert!(temp.path().exists());
+    }
+
+    #[test]
+    fn test_default_db_path_in() {
+        let dir = Path::new("/some/data/dir");
+        assert_eq!(default_db_path_in(dir), PathBuf::from("/some/data/dir/default.db"));
+    }
+}

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,9 +1,11 @@
 pub mod connection;
+pub mod data_dir;
 pub mod entities_repository;
 pub mod migrations;
 pub mod thoughts_repository;
 
-pub use connection::{default_db_path, get_connection, get_memory_connection};
+pub use connection::{get_connection, get_memory_connection};
+pub use data_dir::{default_db_path_in, ensure_data_dir, resolve_data_dir};
 pub use entities_repository::EntitiesRepository;
 pub use migrations::run_migrations;
 pub use thoughts_repository::ThoughtsRepository;

--- a/tests/integration/test_cli_execution.rs
+++ b/tests/integration/test_cli_execution.rs
@@ -8,7 +8,7 @@ fn test_add_execute_success() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("Test thought".to_string(), None, Some(&db_path));
+    let result = add::execute("Test thought".to_string(), None, &db_path);
     assert!(result.is_ok());
 }
 
@@ -17,7 +17,7 @@ fn test_add_execute_empty_fails() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("".to_string(), None, Some(&db_path));
+    let result = add::execute("".to_string(), None, &db_path);
     assert!(result.is_err());
 }
 
@@ -27,7 +27,7 @@ fn test_add_execute_too_long_fails() {
     let db_path = temp_dir.path().join("test.db");
 
     let long_content = "a".repeat(10_001);
-    let result = add::execute(long_content, None, Some(&db_path));
+    let result = add::execute(long_content, None, &db_path);
     assert!(result.is_err());
 }
 
@@ -36,7 +36,7 @@ fn test_notes_execute_empty_db() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = thoughts::execute(Some(&db_path), None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never);
     assert!(result.is_ok());
 }
 
@@ -46,11 +46,11 @@ fn test_notes_execute_with_notes() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add some thoughts first
-    add::execute("First thought".to_string(), None, Some(&db_path)).unwrap();
-    add::execute("Second thought".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("First thought".to_string(), None, &db_path).unwrap();
+    add::execute("Second thought".to_string(), None, &db_path).unwrap();
 
     // List them
-    let result = thoughts::execute(Some(&db_path), None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never);
     assert!(result.is_ok());
 }
 
@@ -60,16 +60,16 @@ fn test_notes_execute_with_entity_filter() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
-    add::execute("Call [John]".to_string(), None, Some(&db_path)).unwrap();
-    add::execute("Email [Sarah] the report".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
+    add::execute("Call [John]".to_string(), None, &db_path).unwrap();
+    add::execute("Email [Sarah] the report".to_string(), None, &db_path).unwrap();
 
     // Filter by Sarah
-    let result = thoughts::execute(Some(&db_path), Some("Sarah"), ColorMode::Never);
+    let result = thoughts::execute(&db_path, Some("Sarah"), ColorMode::Never);
     assert!(result.is_ok());
 
     // Filter by non-existent entity
-    let result = thoughts::execute(Some(&db_path), Some("NonExistent"), ColorMode::Never);
+    let result = thoughts::execute(&db_path, Some("NonExistent"), ColorMode::Never);
     assert!(result.is_ok());
 }
 
@@ -78,7 +78,7 @@ fn test_entities_execute_empty_db() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = wetware::cli::entities::execute(Some(&db_path));
+    let result = wetware::cli::entities::execute(&db_path);
     assert!(result.is_ok());
 }
 
@@ -88,12 +88,12 @@ fn test_entities_execute_with_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
-    add::execute("Call [John]".to_string(), None, Some(&db_path)).unwrap();
-    add::execute("Email [Alice]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
+    add::execute("Call [John]".to_string(), None, &db_path).unwrap();
+    add::execute("Email [Alice]".to_string(), None, &db_path).unwrap();
 
     // List entities
-    let result = wetware::cli::entities::execute(Some(&db_path));
+    let result = wetware::cli::entities::execute(&db_path);
     assert!(result.is_ok());
 }
 
@@ -105,7 +105,7 @@ fn test_add_execute_with_date() {
     let result = add::execute(
         "Backdated thought".to_string(),
         Some("2024-03-15".to_string()),
-        Some(&db_path),
+        &db_path,
     );
     assert!(result.is_ok());
 }
@@ -118,7 +118,7 @@ fn test_add_execute_with_invalid_date() {
     let result = add::execute(
         "Bad date thought".to_string(),
         Some("not-a-date".to_string()),
-        Some(&db_path),
+        &db_path,
     );
     assert!(result.is_err());
 }

--- a/tests/integration/test_entity_references.rs
+++ b/tests/integration/test_entity_references.rs
@@ -93,12 +93,12 @@ fn test_add_command_extracts_entities() {
     let result = add::execute(
         "Discussed [project-alpha] with [Sarah] and [John]".to_string(),
         None,
-        Some(&db_path),
+        &db_path,
     );
     assert!(result.is_ok());
 
     // Verify entities were extracted and saved
-    let conn = wetware::storage::connection::get_connection(Some(&db_path)).unwrap();
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
     let entities = EntitiesRepository::list_all(&conn).unwrap();
 
     assert_eq!(entities.len(), 3);
@@ -114,11 +114,11 @@ fn test_add_command_no_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add a thought without entities
-    let result = add::execute("Regular thought without entities".to_string(), None, Some(&db_path));
+    let result = add::execute("Regular thought without entities".to_string(), None, &db_path);
     assert!(result.is_ok());
 
     // Verify no entities were created
-    let conn = wetware::storage::connection::get_connection(Some(&db_path)).unwrap();
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
     let entities = EntitiesRepository::list_all(&conn).unwrap();
     assert_eq!(entities.len(), 0);
 }

--- a/tests/integration/test_styled_output.rs
+++ b/tests/integration/test_styled_output.rs
@@ -9,10 +9,10 @@ fn test_styled_output_with_color_always() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with colors always on (even though we're not in a TTY)
-    let result = thoughts::execute(Some(&db_path), None, ColorMode::Always);
+    let result = thoughts::execute(&db_path, None, ColorMode::Always);
     assert!(result.is_ok());
 }
 
@@ -22,10 +22,10 @@ fn test_styled_output_with_color_never() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with colors disabled
-    let result = thoughts::execute(Some(&db_path), None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never);
     assert!(result.is_ok());
 }
 
@@ -35,10 +35,10 @@ fn test_styled_output_with_color_auto() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with auto-detection (will be plain since tests aren't TTY)
-    let result = thoughts::execute(Some(&db_path), None, ColorMode::Auto);
+    let result = thoughts::execute(&db_path, None, ColorMode::Auto);
     assert!(result.is_ok());
 }
 

--- a/tests/test_helpers.rs
+++ b/tests/test_helpers.rs
@@ -29,10 +29,11 @@ pub fn run_wet_command(args: &[&str], db_dir: Option<&TempDir>) -> CommandResult
     // Run the built binary directly
     let mut cmd = Command::new("target/debug/wet");
 
-    // Add database path if temp dir provided
+    // Add database and data directory paths if temp dir provided
     if let Some(dir) = db_dir {
         let db_path = dir.path().join("test.db");
         cmd.env("WETWARE_DB", db_path.to_str().unwrap());
+        cmd.env("WETWARE_DATA_DIR", dir.path().to_str().unwrap());
     }
 
     for arg in args {


### PR DESCRIPTION
## Summary

- Replace fragile `wetware.db` in current directory with a proper XDG data directory (`~/.local/share/wetware/`) containing `default.db` and `config.toml`
- Auto-create the directory, database, and default TOML config on first run
- Debug builds panic if `WETWARE_DATA_DIR` is not explicitly set, preventing dev/test from ever touching production data — only release builds resolve the real XDG path

## Test plan

- [x] All 297 existing tests pass (contract tests updated to set `WETWARE_DATA_DIR`)
- [x] `cargo clippy` clean
- [ ] Manual: delete `~/.local/share/wetware/`, run release binary — directory, db, and config created
- [ ] Manual: `WETWARE_DATA_DIR=/tmp/wettest wet add "test"` — uses override directory
- [ ] Manual: `WETWARE_DB=/tmp/test.db wet add "test"` — db override still works

🤖 Generated with [Claude Code](https://claude.com/claude-code)