### PR TITLE
feat: add --date option to wet add command

### DIFF
--- a/specs/001-networked-notes.md
+++ b/specs/001-networked-notes.md
@@ -7,6 +7,7 @@ Foundational feature: capture short notes via CLI that can reference named entit
 ## Requirements
 
 - `wet add '<text>'` saves a note with optional entity references parsed from `[entity-name]` syntax
+- `wet add '<text>' --date YYYY-MM-DD` saves a note with a specific date instead of today
 - `wet thoughts` lists all notes in chronological order (oldest first)
 - `wet thoughts --on <entity>` filters notes by entity reference (case-insensitive)
 - `wet entities` lists all unique entities alphabetically
@@ -54,6 +55,7 @@ Indexes on `thought_entities(entity_id)` and `thought_entities(thought_id)` for 
 
 ```
 wet add '<text>'                 # Add a note (entities auto-extracted)
+wet add '<text>' --date 2024-03-15  # Add a note with a specific date
 wet thoughts                     # List all notes chronologically
 wet thoughts --on <entity>       # Filter notes by entity (case-insensitive)
 wet entities                     # List all unique entities alphabetically
@@ -69,3 +71,4 @@ Output format: `[<id>] <timestamp> - <content>`
 - Nested brackets `[entity[sub]]` are not supported (regex doesn't match)
 - Querying a non-existent entity returns empty results with a helpful message
 - Duplicate entity references in a single note are deduplicated
+- Invalid `--date` format (not YYYY-MM-DD) is rejected with a helpful error message

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -7,12 +7,21 @@ use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
+use chrono::NaiveDate;
 use std::path::Path;
 
 /// Execute the add command
-pub fn execute(content: String, db_path: Option<&Path>) -> Result<(), ThoughtError> {
+pub fn execute(content: String, date: Option<String>, db_path: Option<&Path>) -> Result<(), ThoughtError> {
     // Create and validate thought
-    let thought = Thought::new(content.clone())?;
+    let thought = if let Some(ref date_str) = date {
+        let naive = NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {
+            ThoughtError::InvalidInput(format!("Invalid date format '{}'. Expected YYYY-MM-DD.", date_str))
+        })?;
+        let datetime = naive.and_hms_opt(0, 0, 0).unwrap().and_utc();
+        Thought::new_with_date(content.clone(), datetime)?
+    } else {
+        Thought::new(content.clone())?
+    };
 
     // Get database connection
     let conn = get_connection(db_path)?;

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -27,6 +27,9 @@ pub enum Commands {
     Add {
         /// Thought content
         content: String,
+        /// Date for the thought in YYYY-MM-DD format (defaults to today)
+        #[arg(long)]
+        date: Option<String>,
     },
     /// List all thoughts
     Thoughts {

--- a/src/main.rs
+++ b/src/main.rs
@@ -12,7 +12,7 @@ fn main() {
 
     let result = match cli.command {
         Commands::Tui => wetware::cli::tui::execute(db_path.as_deref()),
-        Commands::Add { content } => wetware::cli::add::execute(content, db_path.as_deref()),
+        Commands::Add { content, date } => wetware::cli::add::execute(content, date, db_path.as_deref()),
         Commands::Edit {
             id,
             content,

--- a/src/models/thought.rs
+++ b/src/models/thought.rs
@@ -20,6 +20,16 @@ impl Thought {
         })
     }
 
+    /// Create a new thought with a specific date
+    pub fn new_with_date(content: String, created_at: DateTime<Utc>) -> Result<Self, ThoughtError> {
+        Self::validate_content(&content)?;
+        Ok(Self {
+            id: None,
+            content,
+            created_at,
+        })
+    }
+
     /// Validate thought content
     fn validate_content(content: &str) -> Result<(), ThoughtError> {
         let trimmed = content.trim();
@@ -77,6 +87,25 @@ mod tests {
         let max_content = "a".repeat(10_000);
         let thought = Thought::new(max_content).unwrap();
         assert_eq!(thought.content.len(), 10_000);
+    }
+
+    #[test]
+    fn test_new_with_date() {
+        let date = chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+            .unwrap()
+            .and_hms_opt(0, 0, 0)
+            .unwrap()
+            .and_utc();
+        let thought = Thought::new_with_date("Backdated thought".to_string(), date).unwrap();
+        assert_eq!(thought.content, "Backdated thought");
+        assert_eq!(thought.created_at, date);
+    }
+
+    #[test]
+    fn test_new_with_date_validates_content() {
+        let date = Utc::now();
+        let result = Thought::new_with_date("".to_string(), date);
+        assert!(matches!(result, Err(ThoughtError::EmptyContent)));
     }
 
     #[test]

--- a/tests/contract/test_add_command.rs
+++ b/tests/contract/test_add_command.rs
@@ -59,3 +59,29 @@ fn test_add_command_whitespace_only() {
         result.stderr
     );
 }
+
+#[test]
+fn test_add_command_with_date() {
+    let temp_db = setup_temp_db();
+    let result = run_wet_command(&["add", "Backdated thought", "--date", "2024-03-15"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed with valid date");
+    assert!(
+        result.stdout.contains("Thought added"),
+        "Should confirm thought was added. Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_add_command_with_invalid_date() {
+    let temp_db = setup_temp_db();
+    let result = run_wet_command(&["add", "Bad date thought", "--date", "not-a-date"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail with invalid date");
+    assert!(
+        result.stderr.contains("Invalid date format"),
+        "Should report invalid date error. Got: {}",
+        result.stderr
+    );
+}

--- a/tests/integration/test_cli_execution.rs
+++ b/tests/integration/test_cli_execution.rs
@@ -8,7 +8,7 @@ fn test_add_execute_success() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("Test thought".to_string(), Some(&db_path));
+    let result = add::execute("Test thought".to_string(), None, Some(&db_path));
     assert!(result.is_ok());
 }
 
@@ -17,7 +17,7 @@ fn test_add_execute_empty_fails() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("".to_string(), Some(&db_path));
+    let result = add::execute("".to_string(), None, Some(&db_path));
     assert!(result.is_err());
 }
 
@@ -27,7 +27,7 @@ fn test_add_execute_too_long_fails() {
     let db_path = temp_dir.path().join("test.db");
 
     let long_content = "a".repeat(10_001);
-    let result = add::execute(long_content, Some(&db_path));
+    let result = add::execute(long_content, None, Some(&db_path));
     assert!(result.is_err());
 }
 
@@ -46,8 +46,8 @@ fn test_notes_execute_with_notes() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add some thoughts first
-    add::execute("First thought".to_string(), Some(&db_path)).unwrap();
-    add::execute("Second thought".to_string(), Some(&db_path)).unwrap();
+    add::execute("First thought".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Second thought".to_string(), None, Some(&db_path)).unwrap();
 
     // List them
     let result = thoughts::execute(Some(&db_path), None, ColorMode::Never);
@@ -60,9 +60,9 @@ fn test_notes_execute_with_entity_filter() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), Some(&db_path)).unwrap();
-    add::execute("Call [John]".to_string(), Some(&db_path)).unwrap();
-    add::execute("Email [Sarah] the report".to_string(), Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Call [John]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Email [Sarah] the report".to_string(), None, Some(&db_path)).unwrap();
 
     // Filter by Sarah
     let result = thoughts::execute(Some(&db_path), Some("Sarah"), ColorMode::Never);
@@ -88,11 +88,37 @@ fn test_entities_execute_with_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), Some(&db_path)).unwrap();
-    add::execute("Call [John]".to_string(), Some(&db_path)).unwrap();
-    add::execute("Email [Alice]".to_string(), Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Call [John]".to_string(), None, Some(&db_path)).unwrap();
+    add::execute("Email [Alice]".to_string(), None, Some(&db_path)).unwrap();
 
     // List entities
     let result = wetware::cli::entities::execute(Some(&db_path));
     assert!(result.is_ok());
+}
+
+#[test]
+fn test_add_execute_with_date() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let result = add::execute(
+        "Backdated thought".to_string(),
+        Some("2024-03-15".to_string()),
+        Some(&db_path),
+    );
+    assert!(result.is_ok());
+}
+
+#[test]
+fn test_add_execute_with_invalid_date() {
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let result = add::execute(
+        "Bad date thought".to_string(),
+        Some("not-a-date".to_string()),
+        Some(&db_path),
+    );
+    assert!(result.is_err());
 }

--- a/tests/integration/test_entity_references.rs
+++ b/tests/integration/test_entity_references.rs
@@ -92,6 +92,7 @@ fn test_add_command_extracts_entities() {
     // Add a thought with entities
     let result = add::execute(
         "Discussed [project-alpha] with [Sarah] and [John]".to_string(),
+        None,
         Some(&db_path),
     );
     assert!(result.is_ok());
@@ -113,7 +114,7 @@ fn test_add_command_no_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add a thought without entities
-    let result = add::execute("Regular thought without entities".to_string(), Some(&db_path));
+    let result = add::execute("Regular thought without entities".to_string(), None, Some(&db_path));
     assert!(result.is_ok());
 
     // Verify no entities were created

--- a/tests/integration/test_styled_output.rs
+++ b/tests/integration/test_styled_output.rs
@@ -9,7 +9,7 @@ fn test_styled_output_with_color_always() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
 
     // Execute with colors always on (even though we're not in a TTY)
     let result = thoughts::execute(Some(&db_path), None, ColorMode::Always);
@@ -22,7 +22,7 @@ fn test_styled_output_with_color_never() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
 
     // Execute with colors disabled
     let result = thoughts::execute(Some(&db_path), None, ColorMode::Never);
@@ -35,7 +35,7 @@ fn test_styled_output_with_color_auto() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), Some(&db_path)).unwrap();
+    add::execute("Meeting with [Sarah]".to_string(), None, Some(&db_path)).unwrap();
 
     // Execute with auto-detection (will be plain since tests aren't TTY)
     let result = thoughts::execute(Some(&db_path), None, ColorMode::Auto);

--- a/tests/integration/test_thought_persistence.rs
+++ b/tests/integration/test_thought_persistence.rs
@@ -70,6 +70,26 @@ fn test_list_notes_chronological_order() -> Result<(), ThoughtError> {
 }
 
 #[test]
+fn test_save_and_retrieve_with_custom_date() -> Result<(), ThoughtError> {
+    let conn = get_memory_connection()?;
+    run_migrations(&conn)?;
+
+    let date = chrono::NaiveDate::from_ymd_opt(2024, 3, 15)
+        .unwrap()
+        .and_hms_opt(0, 0, 0)
+        .unwrap()
+        .and_utc();
+    let thought = Thought::new_with_date("Backdated thought".to_string(), date)?;
+    let saved_id = ThoughtsRepository::save(&conn, &thought)?;
+
+    let retrieved = ThoughtsRepository::get_by_id(&conn, saved_id)?;
+    assert_eq!(retrieved.content, "Backdated thought");
+    assert_eq!(retrieved.created_at, date);
+
+    Ok(())
+}
+
+#[test]
 fn test_empty_database_returns_empty_list() -> Result<(), ThoughtError> {
     let conn = get_memory_connection()?;
     run_migrations(&conn)?;


### PR DESCRIPTION
## Summary

- Add `--date YYYY-MM-DD` option to `wet add` for backdating thoughts
- Defaults to today when omitted, preserving existing behavior
- Reuses the same date parsing logic as `wet edit --date`

## Test plan

- [x] Model tests: `Thought::new_with_date` validates content and preserves date
- [x] Integration tests: `add::execute` with valid date, invalid date
- [x] Contract tests: CLI `wet add --date 2024-03-15` succeeds, invalid date errors
- [x] Persistence test: date round-trips through save/retrieve
- [x] All 292 tests pass, clippy clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)