### PR TITLE
feat: hide time from thought display in CLI and TUI

### DIFF
--- a/src/cli/thoughts.rs
+++ b/src/cli/thoughts.rs
@@ -44,7 +44,7 @@ pub fn execute(db_path: &Path, entity_filter: Option<&str>, color_mode: ColorMod
             println!(
                 "[{}] {} - {}",
                 thought.id.unwrap_or(0),
-                thought.created_at.format("%Y-%m-%d %H:%M:%S"),
+                thought.created_at.format("%Y-%m-%d"),
                 styled_content
             );
         }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -185,7 +185,7 @@ fn render_thought_list(app: &App, frame: &mut Frame, area: Rect) {
         .iter()
         .map(|&idx| {
             let thought = &app.thoughts[idx];
-            let date_str = thought.created_at.format("%Y-%m-%d %H:%M").to_string();
+            let date_str = thought.created_at.format("%Y-%m-%d").to_string();
             let date_span = Span::styled(format!("{} ", date_str), Style::default().fg(Color::DarkGray));
 
             let content_max = inner_width.saturating_sub(date_str.len() + 1);
@@ -242,7 +242,7 @@ fn render_confirm_delete(app: &App, frame: &mut Frame, area: Rect) {
     };
 
     let thought = &app.thoughts[thought_index];
-    let date_str = thought.created_at.format("%Y-%m-%d %H:%M").to_string();
+    let date_str = thought.created_at.format("%Y-%m-%d").to_string();
 
     let popup_area = centered_rect(60, 30, area);
     frame.render_widget(Clear, popup_area);


### PR DESCRIPTION
## Summary
- Remove time (hours/minutes/seconds) from thought display in both `wet thoughts` CLI output and TUI list/detail views
- Thoughts are date-oriented notes — showing time wastes space without adding value
- Only the date (YYYY-MM-DD) is now shown

## Test plan
- [x] All 323 existing tests pass
- [ ] Run `wet thoughts` and verify only dates are shown (no HH:MM:SS)
- [ ] Open TUI and verify thought list shows only dates (no HH:MM)
- [ ] Verify delete confirmation popup shows only date

🤖 Generated with [Claude Code](https://claude.com/claude-code)