### PR TITLE
fix: trim thought content to remove blank lines in CLI output

### DIFF
--- a/src/cli/thoughts.rs
+++ b/src/cli/thoughts.rs
@@ -40,7 +40,7 @@ pub fn execute(db_path: &Path, entity_filter: Option<&str>, color_mode: ColorMod
         let mut styler = EntityStyler::new(use_colors);
 
         for thought in thoughts {
-            let styled_content = styler.render_content(&thought.content);
+            let styled_content = styler.render_content(thought.content.trim());
             println!(
                 "[{}] {} - {}",
                 thought.id.unwrap_or(0),


### PR DESCRIPTION
## Summary
- Trim trailing whitespace from thought content before rendering in `wet thoughts`
- Fixes blank lines appearing between entries caused by trailing newlines in stored content

## Test plan
- [x] All 323 tests pass
- [ ] Run `wet thoughts` and verify no blank lines between entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)