### PR TITLE
feat: add `wet config` command with thoughts.order setting

### DIFF
--- a/specs/009-config-command.md
+++ b/specs/009-config-command.md
@@ -1,0 +1,40 @@
+# 009: Config Command
+
+## Summary
+
+A `wet config` command for reading and setting configuration values using dotted `section.item` keys, mimicking `git config`. The first supported key is `thoughts.order`, which controls whether thoughts are listed newest-first or oldest-first in both CLI and TUI output.
+
+## Requirements
+
+- `wet config <key>` prints the current value of a configuration key
+- `wet config <key> <value>` sets the value of a configuration key
+- Keys use `section.item` dot notation (e.g. `thoughts.order`)
+- Unknown keys produce an error
+- Invalid values produce an error listing valid options
+- `thoughts.order` accepts `ascending` (oldest first) or `descending` (newest first)
+- `thoughts.order` defaults to `descending` when not explicitly set
+- `wet thoughts` CLI output respects `thoughts.order`
+- TUI launches with the sort order from `thoughts.order`; the `s` key still toggles interactively
+
+## Decisions
+
+- **Hardcoded key matching**: Config get/set uses explicit match arms per key rather than dynamic TOML manipulation. The config schema is small and typed; this keeps validation tight and avoids losing type safety.
+- **Shared `SortOrder` type**: The `SortOrder` enum moves from `src/tui/state.rs` to `src/models/sort_order.rs` since it is a domain concept used by config, CLI, and TUI.
+- **TOML nested sections**: `thoughts.order` maps to a `[thoughts]` TOML section with an `order` field. Serde defaults ensure backward compatibility with existing config files that lack this section.
+- **No database needed**: The `config` command operates only on the config file in the data directory, not on the database.
+
+## CLI Interface
+
+```
+wet config thoughts.order            # Prints: descending (or ascending)
+wet config thoughts.order ascending  # Sets order to ascending
+wet config thoughts.order descending # Sets order to descending
+wet config unknown.key               # Error: Unknown config key: unknown.key
+wet config thoughts.order invalid    # Error: Invalid value 'invalid' for thoughts.order. Valid values: ascending, descending
+```
+
+## Edge Cases
+
+- Config file has only `version = 1` (no `[thoughts]` section) → `thoughts.order` defaults to `descending`
+- Config file does not exist → created with defaults on first access (existing `ensure_config` behavior)
+- Multiple `wet config` set calls → last write wins, entire config is rewritten each time

--- a/src/cli/config.rs
+++ b/src/cli/config.rs
@@ -1,0 +1,18 @@
+/// Config command implementation
+use crate::config;
+use crate::errors::ThoughtError;
+use std::path::Path;
+
+/// Execute the config command
+pub fn execute(data_dir: &Path, key: String, value: Option<String>) -> Result<(), ThoughtError> {
+    if let Some(value) = value {
+        let mut cfg = config::load_config(data_dir)?;
+        cfg.set_value(&key, &value)?;
+        config::save_config(data_dir, &cfg)?;
+    } else {
+        let cfg = config::load_config(data_dir)?;
+        let current = cfg.get_value(&key)?;
+        println!("{current}");
+    }
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -1,5 +1,6 @@
 /// CLI module for command-line interface
 pub mod add;
+pub mod config;
 pub mod delete;
 pub mod edit;
 pub mod entities;
@@ -55,6 +56,13 @@ pub enum Commands {
     Delete {
         /// ID of the thought to delete (visible in `wet` listing output as [id])
         id: i64,
+    },
+    /// Get or set configuration values
+    Config {
+        /// Configuration key in section.item format (e.g. thoughts.order)
+        key: String,
+        /// Value to set (omit to read current value)
+        value: Option<String>,
     },
     /// Launch interactive TUI thought viewer
     Tui,

--- a/src/cli/thoughts.rs
+++ b/src/cli/thoughts.rs
@@ -1,5 +1,6 @@
 /// Thoughts command implementation
 use crate::errors::ThoughtError;
+use crate::models::SortOrder;
 use crate::services::color_mode::ColorMode;
 use crate::services::entity_styler::EntityStyler;
 use crate::storage::connection::get_connection;
@@ -8,25 +9,24 @@ use crate::storage::thoughts_repository::ThoughtsRepository;
 use std::path::Path;
 
 /// Execute the thoughts command
-///
-/// # Arguments
-///
-/// * `db_path` - Optional path to the database file
-/// * `entity_filter` - Optional entity name to filter thoughts by
-/// * `color_mode` - Controls whether output should be styled with colors
-pub fn execute(db_path: &Path, entity_filter: Option<&str>, color_mode: ColorMode) -> Result<(), ThoughtError> {
-    // Get database connection
+pub fn execute(
+    db_path: &Path,
+    entity_filter: Option<&str>,
+    color_mode: ColorMode,
+    sort_order: SortOrder,
+) -> Result<(), ThoughtError> {
     let conn = get_connection(db_path)?;
-
-    // Run migrations if needed
     run_migrations(&conn)?;
 
-    // Get thoughts (filtered by entity if specified)
-    let thoughts = if let Some(entity_name) = entity_filter {
+    let mut thoughts = if let Some(entity_name) = entity_filter {
         ThoughtsRepository::list_by_entity(&conn, entity_name)?
     } else {
         ThoughtsRepository::list_all(&conn)?
     };
+
+    if sort_order == SortOrder::Descending {
+        thoughts.reverse();
+    }
 
     if thoughts.is_empty() {
         if let Some(entity_name) = entity_filter {
@@ -35,7 +35,6 @@ pub fn execute(db_path: &Path, entity_filter: Option<&str>, color_mode: ColorMod
             println!("No thoughts found.");
         }
     } else {
-        // Create entity styler based on color mode
         let use_colors = color_mode.should_use_colors();
         let mut styler = EntityStyler::new(use_colors);
 

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -6,29 +6,24 @@
 use std::path::Path;
 
 use crate::errors::ThoughtError;
+use crate::models::SortOrder;
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 use crate::tui::App;
 
 /// Launch the interactive TUI thought viewer.
-///
-/// Opens the database, loads all thoughts and entities, initializes a full-screen
-/// terminal, and runs the TUI event loop. Terminal state is restored on exit.
-pub fn execute(db_path: &Path) -> Result<(), ThoughtError> {
+pub fn execute(db_path: &Path, sort_order: SortOrder) -> Result<(), ThoughtError> {
     let conn = get_connection(db_path)?;
     let thoughts = ThoughtsRepository::list_all(&conn)?;
     let entities = EntitiesRepository::list_all(&conn)?;
 
-    // Initialize terminal
     let mut terminal = ratatui::init();
 
-    // Run the app, capturing any error to ensure terminal cleanup
-    let result = App::new(thoughts, entities)
+    let result = App::new(thoughts, entities, sort_order)
         .with_db_path(db_path.to_path_buf())
         .run(&mut terminal);
 
-    // Always restore terminal, even if app errored
     ratatui::restore();
 
     result

--- a/src/config.rs
+++ b/src/config.rs
@@ -1,18 +1,68 @@
 /// Configuration file management
 use crate::errors::ThoughtError;
+use crate::models::SortOrder;
 use serde::{Deserialize, Serialize};
 use std::path::Path;
+
+fn default_thoughts_order() -> SortOrder {
+    SortOrder::Descending
+}
+
+/// Configuration for thought listing behavior
+#[derive(Debug, Serialize, Deserialize, PartialEq)]
+pub struct ThoughtsConfig {
+    #[serde(default = "default_thoughts_order")]
+    pub order: SortOrder,
+}
+
+impl Default for ThoughtsConfig {
+    fn default() -> Self {
+        Self {
+            order: default_thoughts_order(),
+        }
+    }
+}
 
 /// Wetware configuration
 #[derive(Debug, Serialize, Deserialize, PartialEq)]
 pub struct Config {
     /// Configuration format version for future migrations
     pub version: u32,
+    #[serde(default)]
+    pub thoughts: ThoughtsConfig,
 }
 
 impl Default for Config {
     fn default() -> Self {
-        Self { version: 1 }
+        Self {
+            version: 1,
+            thoughts: ThoughtsConfig::default(),
+        }
+    }
+}
+
+impl Config {
+    /// Get a config value by dotted key (e.g. "thoughts.order").
+    pub fn get_value(&self, key: &str) -> Result<String, ThoughtError> {
+        match key {
+            "thoughts.order" => Ok(self.thoughts.order.to_string()),
+            _ => Err(ThoughtError::InvalidInput(format!("Unknown config key: {key}"))),
+        }
+    }
+
+    /// Set a config value by dotted key.
+    pub fn set_value(&mut self, key: &str, value: &str) -> Result<(), ThoughtError> {
+        match key {
+            "thoughts.order" => {
+                self.thoughts.order = value.parse().map_err(|_| {
+                    ThoughtError::InvalidInput(format!(
+                        "Invalid value '{value}' for thoughts.order. Valid values: ascending, descending"
+                    ))
+                })?;
+                Ok(())
+            }
+            _ => Err(ThoughtError::InvalidInput(format!("Unknown config key: {key}"))),
+        }
     }
 }
 
@@ -61,6 +111,7 @@ mod tests {
     fn test_default_config() {
         let config = Config::default();
         assert_eq!(config.version, 1);
+        assert_eq!(config.thoughts.order, SortOrder::Descending);
     }
 
     #[test]
@@ -73,7 +124,8 @@ mod tests {
     #[test]
     fn test_save_and_load_config() {
         let temp = TempDir::new().unwrap();
-        let config = Config { version: 2 };
+        let mut config = Config::default();
+        config.thoughts.order = SortOrder::Ascending;
         save_config(temp.path(), &config).unwrap();
         let loaded = load_config(temp.path()).unwrap();
         assert_eq!(loaded, config);
@@ -102,7 +154,9 @@ mod tests {
     #[test]
     fn test_ensure_config_preserves_existing() {
         let temp = TempDir::new().unwrap();
-        let custom = Config { version: 5 };
+        let mut custom = Config::default();
+        custom.version = 5;
+        custom.thoughts.order = SortOrder::Ascending;
         save_config(temp.path(), &custom).unwrap();
         let config = ensure_config(temp.path()).unwrap();
         assert_eq!(config, custom);
@@ -114,5 +168,59 @@ mod tests {
         let serialized = toml::to_string_pretty(&config).unwrap();
         let deserialized: Config = toml::from_str(&serialized).unwrap();
         assert_eq!(config, deserialized);
+    }
+
+    #[test]
+    fn test_backward_compat_version_only() {
+        let toml_str = "version = 1\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.version, 1);
+        assert_eq!(config.thoughts.order, SortOrder::Descending);
+    }
+
+    #[test]
+    fn test_backward_compat_no_order_in_thoughts() {
+        let toml_str = "version = 1\n\n[thoughts]\n";
+        let config: Config = toml::from_str(toml_str).unwrap();
+        assert_eq!(config.thoughts.order, SortOrder::Descending);
+    }
+
+    #[test]
+    fn test_get_value_thoughts_order() {
+        let config = Config::default();
+        assert_eq!(config.get_value("thoughts.order").unwrap(), "descending");
+    }
+
+    #[test]
+    fn test_get_value_unknown_key() {
+        let config = Config::default();
+        let result = config.get_value("unknown.key");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown config key"));
+    }
+
+    #[test]
+    fn test_set_value_thoughts_order() {
+        let mut config = Config::default();
+        config.set_value("thoughts.order", "ascending").unwrap();
+        assert_eq!(config.thoughts.order, SortOrder::Ascending);
+    }
+
+    #[test]
+    fn test_set_value_invalid_value() {
+        let mut config = Config::default();
+        let result = config.set_value("thoughts.order", "invalid");
+        assert!(result.is_err());
+        let err = result.unwrap_err().to_string();
+        assert!(err.contains("Invalid value 'invalid'"));
+        assert!(err.contains("ascending, descending"));
+    }
+
+    #[test]
+    fn test_set_value_unknown_key() {
+        let mut config = Config::default();
+        let result = config.set_value("unknown.key", "value");
+        assert!(result.is_err());
+        assert!(result.unwrap_err().to_string().contains("Unknown config key"));
     }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -9,4 +9,4 @@ pub mod storage;
 pub mod tui;
 
 pub use errors::ThoughtError;
-pub use models::{Entity, Thought};
+pub use models::{Entity, SortOrder, Thought};

--- a/src/main.rs
+++ b/src/main.rs
@@ -27,10 +27,13 @@ fn main() {
         eprintln!("Error creating data directory: {e}");
         process::exit(1);
     }
-    if let Err(e) = config::ensure_config(&data_dir) {
-        eprintln!("Error initializing config: {e}");
-        process::exit(1);
-    }
+    let config = match config::ensure_config(&data_dir) {
+        Ok(c) => c,
+        Err(e) => {
+            eprintln!("Error initializing config: {e}");
+            process::exit(1);
+        }
+    };
 
     // Database path: WETWARE_DB env var > <data_dir>/default.db
     let db_path = env::var("WETWARE_DB")
@@ -40,8 +43,9 @@ fn main() {
         .unwrap_or_else(|| default_db_path_in(&data_dir));
 
     let result = match cli.command {
+        Commands::Config { key, value } => wetware::cli::config::execute(&data_dir, key, value),
         Commands::Delete { id } => wetware::cli::delete::execute(id, &db_path),
-        Commands::Tui => wetware::cli::tui::execute(&db_path),
+        Commands::Tui => wetware::cli::tui::execute(&db_path, config.thoughts.order),
         Commands::Add { content, date } => wetware::cli::add::execute(content, date, &db_path),
         Commands::Edit {
             id,
@@ -49,7 +53,9 @@ fn main() {
             date,
             editor,
         } => wetware::cli::edit::execute(id, content, date, editor, &db_path),
-        Commands::Thoughts { on } => wetware::cli::thoughts::execute(&db_path, on.as_deref(), cli.color),
+        Commands::Thoughts { on } => {
+            wetware::cli::thoughts::execute(&db_path, on.as_deref(), cli.color, config.thoughts.order)
+        }
         Commands::Entities => wetware::cli::entities::execute(&db_path),
         Commands::Entity { command } => match command {
             EntityCommands::Edit {

--- a/src/models/mod.rs
+++ b/src/models/mod.rs
@@ -1,5 +1,7 @@
 pub mod entity;
+pub mod sort_order;
 pub mod thought;
 
 pub use entity::Entity;
+pub use sort_order::SortOrder;
 pub use thought::Thought;

--- a/src/models/sort_order.rs
+++ b/src/models/sort_order.rs
@@ -1,0 +1,132 @@
+use serde::{Deserialize, Serialize};
+use std::fmt;
+use std::str::FromStr;
+
+/// Sort order for the thought list.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Serialize, Deserialize)]
+#[serde(rename_all = "lowercase")]
+pub enum SortOrder {
+    /// Oldest thoughts first
+    Ascending,
+    /// Newest thoughts first
+    Descending,
+}
+
+impl SortOrder {
+    /// Toggle between ascending and descending order.
+    pub fn toggle(&mut self) {
+        *self = match self {
+            SortOrder::Ascending => SortOrder::Descending,
+            SortOrder::Descending => SortOrder::Ascending,
+        };
+    }
+
+    /// Human-readable label for the current sort order.
+    pub fn label(&self) -> &str {
+        match self {
+            SortOrder::Ascending => "Oldest first",
+            SortOrder::Descending => "Newest first",
+        }
+    }
+}
+
+impl fmt::Display for SortOrder {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            SortOrder::Ascending => write!(f, "ascending"),
+            SortOrder::Descending => write!(f, "descending"),
+        }
+    }
+}
+
+impl FromStr for SortOrder {
+    type Err = String;
+
+    fn from_str(s: &str) -> Result<Self, Self::Err> {
+        match s {
+            "ascending" => Ok(SortOrder::Ascending),
+            "descending" => Ok(SortOrder::Descending),
+            _ => Err(format!(
+                "Invalid sort order: '{s}'. Valid values: ascending, descending"
+            )),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_sort_order_toggle_ascending_to_descending() {
+        let mut order = SortOrder::Ascending;
+        order.toggle();
+        assert_eq!(order, SortOrder::Descending);
+    }
+
+    #[test]
+    fn test_sort_order_toggle_descending_to_ascending() {
+        let mut order = SortOrder::Descending;
+        order.toggle();
+        assert_eq!(order, SortOrder::Ascending);
+    }
+
+    #[test]
+    fn test_sort_order_label_ascending() {
+        assert_eq!(SortOrder::Ascending.label(), "Oldest first");
+    }
+
+    #[test]
+    fn test_sort_order_label_descending() {
+        assert_eq!(SortOrder::Descending.label(), "Newest first");
+    }
+
+    #[test]
+    fn test_sort_order_double_toggle_returns_to_original() {
+        let mut order = SortOrder::Ascending;
+        order.toggle();
+        order.toggle();
+        assert_eq!(order, SortOrder::Ascending);
+    }
+
+    #[test]
+    fn test_display_ascending() {
+        assert_eq!(SortOrder::Ascending.to_string(), "ascending");
+    }
+
+    #[test]
+    fn test_display_descending() {
+        assert_eq!(SortOrder::Descending.to_string(), "descending");
+    }
+
+    #[test]
+    fn test_from_str_ascending() {
+        assert_eq!("ascending".parse::<SortOrder>().unwrap(), SortOrder::Ascending);
+    }
+
+    #[test]
+    fn test_from_str_descending() {
+        assert_eq!("descending".parse::<SortOrder>().unwrap(), SortOrder::Descending);
+    }
+
+    #[test]
+    fn test_from_str_invalid() {
+        let result = "invalid".parse::<SortOrder>();
+        assert!(result.is_err());
+        assert!(result.unwrap_err().contains("Invalid sort order"));
+    }
+
+    #[test]
+    fn test_serde_roundtrip() {
+        #[derive(Serialize, Deserialize, PartialEq, Debug)]
+        struct Wrapper {
+            order: SortOrder,
+        }
+        let w = Wrapper {
+            order: SortOrder::Descending,
+        };
+        let serialized = toml::to_string(&w).unwrap();
+        let deserialized: Wrapper = toml::from_str(&serialized).unwrap();
+        assert_eq!(w, deserialized);
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -219,7 +219,7 @@ fn handle_entity_detail_mode(app: &mut App, key: KeyEvent) {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Entity, Thought};
+    use crate::models::{Entity, SortOrder, Thought};
     use chrono::Utc;
 
     fn make_thought(content: &str, days_ago: i64) -> Thought {
@@ -245,14 +245,14 @@ mod tests {
 
     #[test]
     fn test_normal_mode_q_quits() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         handle_key_event(&mut app, key_event(KeyCode::Char('q')));
         assert!(app.should_quit);
     }
 
     #[test]
     fn test_normal_mode_esc_quits_without_filter() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         handle_key_event(&mut app, key_event(KeyCode::Esc));
         assert!(app.should_quit);
     }
@@ -260,7 +260,7 @@ mod tests {
     #[test]
     fn test_normal_mode_esc_clears_filter() {
         let thoughts = vec![make_thought("[Sarah] hello", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
 
@@ -272,7 +272,7 @@ mod tests {
     #[test]
     fn test_normal_mode_up_decreases_selection() {
         let thoughts = vec![make_thought("a", 2), make_thought("b", 1), make_thought("c", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(2));
 
         handle_key_event(&mut app, key_event(KeyCode::Up));
@@ -282,7 +282,7 @@ mod tests {
     #[test]
     fn test_normal_mode_up_stops_at_zero() {
         let thoughts = vec![make_thought("a", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(0));
 
         handle_key_event(&mut app, key_event(KeyCode::Up));
@@ -292,7 +292,7 @@ mod tests {
     #[test]
     fn test_normal_mode_down_increases_selection() {
         let thoughts = vec![make_thought("a", 2), make_thought("b", 1)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(0));
 
         handle_key_event(&mut app, key_event(KeyCode::Down));
@@ -302,7 +302,7 @@ mod tests {
     #[test]
     fn test_normal_mode_down_stops_at_end() {
         let thoughts = vec![make_thought("a", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(0));
 
         handle_key_event(&mut app, key_event(KeyCode::Down));
@@ -312,7 +312,7 @@ mod tests {
     #[test]
     fn test_normal_mode_home_selects_first() {
         let thoughts = vec![make_thought("a", 2), make_thought("b", 1), make_thought("c", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(2));
 
         handle_key_event(&mut app, key_event(KeyCode::Home));
@@ -322,7 +322,7 @@ mod tests {
     #[test]
     fn test_normal_mode_end_selects_last() {
         let thoughts = vec![make_thought("a", 2), make_thought("b", 1), make_thought("c", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.list_state.select(Some(0));
 
         handle_key_event(&mut app, key_event(KeyCode::End));
@@ -332,11 +332,11 @@ mod tests {
     #[test]
     fn test_normal_mode_s_toggles_sort() {
         let thoughts = vec![make_thought("newest", 0), make_thought("oldest", 5)];
-        let mut app = App::new(thoughts, vec![]);
-        assert_eq!(app.sort_order, crate::tui::state::SortOrder::Ascending);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
+        assert_eq!(app.sort_order, crate::models::SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Char('s')));
-        assert_eq!(app.sort_order, crate::tui::state::SortOrder::Descending);
+        assert_eq!(app.sort_order, crate::models::SortOrder::Descending);
 
         // Verify order changed
         let first_idx = app.displayed_thoughts[0];
@@ -346,7 +346,7 @@ mod tests {
     #[test]
     fn test_normal_mode_slash_opens_entity_picker() {
         let entities = vec![make_entity("Sarah"), make_entity("Project")];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Char('/')));
         assert!(matches!(app.mode, Mode::EntityPicker { .. }));
@@ -360,7 +360,7 @@ mod tests {
     fn test_normal_mode_enter_opens_entity_detail() {
         let thoughts = vec![make_thought("Meeting with [Sarah]", 0)];
         let entities = vec![make_entity("Sarah")];
-        let mut app = App::new(thoughts, entities);
+        let mut app = App::new(thoughts, entities, SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Enter));
         assert!(matches!(app.mode, Mode::EntityDetail { .. }));
@@ -373,7 +373,7 @@ mod tests {
     #[test]
     fn test_normal_mode_enter_no_entities_stays_normal() {
         let thoughts = vec![make_thought("No entities here", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Enter));
         assert!(matches!(app.mode, Mode::Normal));
@@ -382,7 +382,7 @@ mod tests {
     #[test]
     fn test_entity_picker_esc_returns_to_normal() {
         let entities = vec![make_entity("Sarah")];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityPicker {
             input: tui_input::Input::default(),
             matches: vec![0],
@@ -398,7 +398,7 @@ mod tests {
     fn test_entity_picker_enter_applies_filter() {
         let thoughts = vec![make_thought("[Sarah] hello", 0), make_thought("world", 1)];
         let entities = vec![make_entity("Sarah")];
-        let mut app = App::new(thoughts, entities);
+        let mut app = App::new(thoughts, entities, SortOrder::Ascending);
         app.mode = Mode::EntityPicker {
             input: tui_input::Input::default(),
             matches: vec![0],
@@ -414,7 +414,7 @@ mod tests {
     #[test]
     fn test_entity_picker_up_down_navigation() {
         let entities = vec![make_entity("Alpha"), make_entity("Beta"), make_entity("Gamma")];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityPicker {
             input: tui_input::Input::default(),
             matches: vec![0, 1, 2],
@@ -434,7 +434,7 @@ mod tests {
 
     #[test]
     fn test_entity_detail_esc_returns_to_normal() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0],
             scroll_offset: 0,
@@ -446,7 +446,7 @@ mod tests {
 
     #[test]
     fn test_entity_detail_scroll() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0],
             scroll_offset: 0,
@@ -472,7 +472,7 @@ mod tests {
     #[test]
     fn test_normal_mode_x_opens_confirm_delete() {
         let thoughts = vec![make_thought("to delete", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Char('x')));
         assert!(matches!(app.mode, Mode::ConfirmDelete { thought_index: 0 }));
@@ -480,7 +480,7 @@ mod tests {
 
     #[test]
     fn test_normal_mode_x_no_selection_does_nothing() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
 
         handle_key_event(&mut app, key_event(KeyCode::Char('x')));
         assert!(matches!(app.mode, Mode::Normal));
@@ -489,7 +489,7 @@ mod tests {
     #[test]
     fn test_confirm_delete_n_returns_to_normal() {
         let thoughts = vec![make_thought("to delete", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         handle_key_event(&mut app, key_event(KeyCode::Char('n')));
@@ -499,7 +499,7 @@ mod tests {
     #[test]
     fn test_confirm_delete_esc_returns_to_normal() {
         let thoughts = vec![make_thought("to delete", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         handle_key_event(&mut app, key_event(KeyCode::Esc));
@@ -509,7 +509,7 @@ mod tests {
     #[test]
     fn test_confirm_delete_y_without_db_returns_to_normal() {
         let thoughts = vec![make_thought("to delete", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         // No db_path set, so delete will fail and fall back to Normal
@@ -538,7 +538,7 @@ mod tests {
             created_at: thought.created_at,
         };
 
-        let mut app = App::new(vec![thought_with_id], vec![]).with_db_path(db_path.clone());
+        let mut app = App::new(vec![thought_with_id], vec![], SortOrder::Ascending).with_db_path(db_path.clone());
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         handle_key_event(&mut app, key_event(KeyCode::Char('y')));
@@ -549,7 +549,7 @@ mod tests {
     #[test]
     fn test_confirm_delete_other_keys_ignored() {
         let thoughts = vec![make_thought("to delete", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         handle_key_event(&mut app, key_event(KeyCode::Char('q')));

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -13,13 +13,13 @@ use ratatui::crossterm::event::{self, Event, KeyEventKind};
 use ratatui::{Terminal, backend::Backend};
 
 use crate::errors::ThoughtError;
-use crate::models::{Entity, Thought};
+use crate::models::{Entity, SortOrder, Thought};
 use crate::services::entity_parser;
 use crate::storage::connection::get_connection;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 
-use state::{Mode, SortOrder};
+use state::Mode;
 
 /// Root application state for the TUI viewer.
 ///
@@ -47,18 +47,15 @@ pub struct App {
 }
 
 impl App {
-    /// Create a new App with loaded data.
-    ///
-    /// Initializes with ascending sort order (oldest first), no active filter,
-    /// Normal mode, and all thoughts displayed.
-    pub fn new(thoughts: Vec<Thought>, entities: Vec<Entity>) -> Self {
+    /// Create a new App with loaded data and initial sort order.
+    pub fn new(thoughts: Vec<Thought>, entities: Vec<Entity>, sort_order: SortOrder) -> Self {
         let mut app = Self {
             thoughts,
             entities,
             displayed_thoughts: Vec::new(),
             list_state: ratatui::widgets::ListState::default(),
             mode: Mode::Normal,
-            sort_order: SortOrder::Ascending,
+            sort_order,
             active_filter: None,
             should_quit: false,
             db_path: None,
@@ -217,33 +214,36 @@ mod tests {
             make_thought("thought 2", 1),
             make_thought("thought 3", 0),
         ];
-        let app = App::new(thoughts, vec![]);
+        let app = App::new(thoughts, vec![], SortOrder::Ascending);
         assert_eq!(app.displayed_thoughts.len(), 3);
         assert_eq!(app.list_state.selected(), Some(0));
     }
 
     #[test]
     fn test_new_with_empty_thoughts() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(app.displayed_thoughts.is_empty());
         assert_eq!(app.list_state.selected(), None);
     }
 
     #[test]
-    fn test_new_defaults_to_ascending_sort() {
-        let app = App::new(vec![], vec![]);
+    fn test_new_uses_provided_sort_order() {
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert_eq!(app.sort_order, SortOrder::Ascending);
+
+        let app = App::new(vec![], vec![], SortOrder::Descending);
+        assert_eq!(app.sort_order, SortOrder::Descending);
     }
 
     #[test]
     fn test_new_defaults_to_normal_mode() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(matches!(app.mode, Mode::Normal));
     }
 
     #[test]
     fn test_new_defaults_to_no_filter() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(app.active_filter.is_none());
     }
 
@@ -254,7 +254,7 @@ mod tests {
             make_thought("oldest", 5),
             make_thought("middle", 2),
         ];
-        let app = App::new(thoughts, vec![]);
+        let app = App::new(thoughts, vec![], SortOrder::Ascending);
         // Ascending = oldest first, so thought at index 1 (5 days ago) should be first
         let first_thought_idx = app.displayed_thoughts[0];
         assert_eq!(app.thoughts[first_thought_idx].content, "oldest");
@@ -267,9 +267,7 @@ mod tests {
             make_thought("oldest", 5),
             make_thought("middle", 2),
         ];
-        let mut app = App::new(thoughts, vec![]);
-        app.sort_order = SortOrder::Descending;
-        app.recompute_displayed_thoughts();
+        let app = App::new(thoughts, vec![], SortOrder::Descending);
         let first_thought_idx = app.displayed_thoughts[0];
         assert_eq!(app.thoughts[first_thought_idx].content, "newest");
     }
@@ -281,7 +279,7 @@ mod tests {
             make_thought("No entities here", 1),
             make_thought("Called [Sarah] about [project]", 0),
         ];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
         assert_eq!(app.displayed_thoughts.len(), 2);
@@ -293,7 +291,7 @@ mod tests {
             make_thought("Meeting with [Sarah]", 2),
             make_thought("No entities here", 1),
         ];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
         assert_eq!(app.displayed_thoughts.len(), 1);
@@ -311,7 +309,7 @@ mod tests {
             make_entity("Project", None),
             make_entity("Unrelated", None),
         ];
-        let app = App::new(thoughts, entities);
+        let app = App::new(thoughts, entities, SortOrder::Ascending);
         let indices = app.selected_thought_entity_indices();
         assert_eq!(indices.len(), 2);
         assert!(indices.contains(&0)); // Sarah
@@ -320,13 +318,13 @@ mod tests {
 
     #[test]
     fn test_selected_thought_entity_indices_no_selection() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(app.selected_thought_entity_indices().is_empty());
     }
 
     #[test]
     fn test_quit_flag() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(!app.should_quit);
         app.should_quit = true;
         assert!(app.should_quit);
@@ -334,19 +332,19 @@ mod tests {
 
     #[test]
     fn test_with_db_path() {
-        let app = App::new(vec![], vec![]).with_db_path(std::path::PathBuf::from("/tmp/test.db"));
+        let app = App::new(vec![], vec![], SortOrder::Ascending).with_db_path(std::path::PathBuf::from("/tmp/test.db"));
         assert_eq!(app.db_path, Some(std::path::PathBuf::from("/tmp/test.db")));
     }
 
     #[test]
     fn test_new_has_no_db_path() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         assert!(app.db_path.is_none());
     }
 
     #[test]
     fn test_delete_selected_thought_not_in_confirm_mode() {
-        let mut app = App::new(vec![make_thought("test", 0)], vec![]);
+        let mut app = App::new(vec![make_thought("test", 0)], vec![], SortOrder::Ascending);
         // Not in ConfirmDelete mode — should be a no-op
         let result = app.delete_selected_thought();
         assert!(result.is_ok());
@@ -355,7 +353,7 @@ mod tests {
 
     #[test]
     fn test_delete_selected_thought_no_db_path() {
-        let mut app = App::new(vec![make_thought("test", 0)], vec![]);
+        let mut app = App::new(vec![make_thought("test", 0)], vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
         let result = app.delete_selected_thought();
         assert!(result.is_err());
@@ -383,7 +381,7 @@ mod tests {
             created_at: thought.created_at,
         };
 
-        let mut app = App::new(vec![thought_with_id], vec![]).with_db_path(db_path.clone());
+        let mut app = App::new(vec![thought_with_id], vec![], SortOrder::Ascending).with_db_path(db_path.clone());
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
 
         let result = app.delete_selected_thought();
@@ -428,7 +426,7 @@ mod tests {
             },
         ];
 
-        let mut app = App::new(thoughts, vec![]).with_db_path(db_path);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending).with_db_path(db_path);
         app.list_state.select(Some(1));
         // Delete the last thought (index 1 in thoughts vec)
         app.mode = Mode::ConfirmDelete { thought_index: 1 };

--- a/src/tui/state.rs
+++ b/src/tui/state.rs
@@ -1,6 +1,6 @@
 //! Application state types for the TUI viewer
 //!
-//! Defines the interaction modes and sort order used by the TUI.
+//! Defines the interaction modes used by the TUI.
 
 /// Interaction mode of the TUI.
 ///
@@ -29,68 +29,4 @@ pub enum Mode {
         /// Scroll position within the description popup
         scroll_offset: usize,
     },
-}
-
-/// Sort order for the thought list.
-#[derive(Debug, Clone, Copy, PartialEq, Eq)]
-pub enum SortOrder {
-    /// Oldest thoughts first
-    Ascending,
-    /// Newest thoughts first
-    Descending,
-}
-
-impl SortOrder {
-    /// Toggle between ascending and descending order.
-    pub fn toggle(&mut self) {
-        *self = match self {
-            SortOrder::Ascending => SortOrder::Descending,
-            SortOrder::Descending => SortOrder::Ascending,
-        };
-    }
-
-    /// Human-readable label for the current sort order.
-    pub fn label(&self) -> &str {
-        match self {
-            SortOrder::Ascending => "Oldest first",
-            SortOrder::Descending => "Newest first",
-        }
-    }
-}
-
-#[cfg(test)]
-mod tests {
-    use super::*;
-
-    #[test]
-    fn test_sort_order_toggle_ascending_to_descending() {
-        let mut order = SortOrder::Ascending;
-        order.toggle();
-        assert_eq!(order, SortOrder::Descending);
-    }
-
-    #[test]
-    fn test_sort_order_toggle_descending_to_ascending() {
-        let mut order = SortOrder::Descending;
-        order.toggle();
-        assert_eq!(order, SortOrder::Ascending);
-    }
-
-    #[test]
-    fn test_sort_order_label_ascending() {
-        assert_eq!(SortOrder::Ascending.label(), "Oldest first");
-    }
-
-    #[test]
-    fn test_sort_order_label_descending() {
-        assert_eq!(SortOrder::Descending.label(), "Newest first");
-    }
-
-    #[test]
-    fn test_sort_order_double_toggle_returns_to_original() {
-        let mut order = SortOrder::Ascending;
-        order.toggle();
-        order.toggle();
-        assert_eq!(order, SortOrder::Ascending);
-    }
 }

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -420,7 +420,7 @@ fn centered_rect(percent_x: u16, percent_y: u16, area: Rect) -> Rect {
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::models::{Entity, Thought};
+    use crate::models::{Entity, SortOrder, Thought};
     use chrono::Utc;
     use ratatui::{Terminal, backend::TestBackend};
 
@@ -522,14 +522,14 @@ mod tests {
 
     #[test]
     fn test_render_empty_thoughts_shows_placeholder() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 60, 10);
         assert!(output.contains("No thoughts recorded yet"));
     }
 
     #[test]
     fn test_render_empty_thoughts_with_filter_shows_filter_message() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
         let output = render_to_string(&app, 60, 10);
@@ -540,21 +540,21 @@ mod tests {
     #[test]
     fn test_render_thoughts_shows_content() {
         let thoughts = vec![make_thought("Meeting with team", 0)];
-        let app = App::new(thoughts, vec![]);
+        let app = App::new(thoughts, vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("Meeting with team"));
     }
 
     #[test]
     fn test_render_status_bar_shows_sort_order() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("Sort: Oldest first"));
     }
 
     #[test]
     fn test_render_status_bar_shows_key_hints() {
-        let app = App::new(vec![], vec![]);
+        let app = App::new(vec![], vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("q:Quit"));
     }
@@ -562,7 +562,7 @@ mod tests {
     #[test]
     fn test_render_status_bar_shows_active_filter() {
         let thoughts = vec![make_thought("[Sarah] hello", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
         let output = render_to_string(&app, 80, 10);
@@ -573,7 +573,7 @@ mod tests {
     #[test]
     fn test_render_filtered_title() {
         let thoughts = vec![make_thought("[Sarah] hello", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
         app.recompute_displayed_thoughts();
         let output = render_to_string(&app, 80, 10);
@@ -582,7 +582,7 @@ mod tests {
 
     #[test]
     fn test_render_descending_sort_label() {
-        let mut app = App::new(vec![], vec![]);
+        let mut app = App::new(vec![], vec![], SortOrder::Ascending);
         app.sort_order.toggle();
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("Sort: Newest first"));
@@ -591,7 +591,7 @@ mod tests {
     #[test]
     fn test_render_entity_picker_overlay() {
         let entities = vec![make_entity("Sarah", None), make_entity("Project", None)];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityPicker {
             input: tui_input::Input::default(),
             matches: vec![0, 1],
@@ -607,7 +607,7 @@ mod tests {
     #[test]
     fn test_render_entity_detail_with_description() {
         let entities = vec![make_entity("Sarah", Some("A colleague from work"))];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0],
             scroll_offset: 0,
@@ -621,7 +621,7 @@ mod tests {
     #[test]
     fn test_render_entity_detail_without_description() {
         let entities = vec![make_entity("Sarah", None)];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0],
             scroll_offset: 0,
@@ -636,7 +636,7 @@ mod tests {
             make_entity("Sarah", Some("A person")),
             make_entity("Project", Some("A big project")),
         ];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0, 1],
             scroll_offset: 0,
@@ -655,7 +655,7 @@ mod tests {
             make_thought("Second thought", 1),
             make_thought("Third thought", 0),
         ];
-        let app = App::new(thoughts, vec![]);
+        let app = App::new(thoughts, vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("First thought"));
         assert!(output.contains("Second thought"));
@@ -665,7 +665,7 @@ mod tests {
     #[test]
     fn test_render_thought_shows_date() {
         let thoughts = vec![make_thought("dated thought", 0)];
-        let app = App::new(thoughts, vec![]);
+        let app = App::new(thoughts, vec![], SortOrder::Ascending);
         let output = render_to_string(&app, 80, 10);
         let today = Utc::now().format("%Y-%m-%d").to_string();
         assert!(output.contains(&today));
@@ -688,7 +688,7 @@ mod tests {
             .collect::<Vec<_>>()
             .join("\n\n");
         let entities = vec![make_entity("Sarah", Some(&long_desc))];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityDetail {
             entity_indices: vec![0],
             scroll_offset: 5,
@@ -700,7 +700,7 @@ mod tests {
     #[test]
     fn test_render_confirm_delete_overlay() {
         let thoughts = vec![make_thought("Meeting with team", 0)];
-        let mut app = App::new(thoughts, vec![]);
+        let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.mode = Mode::ConfirmDelete { thought_index: 0 };
         let output = render_to_string(&app, 80, 24);
         assert!(output.contains("Delete Thought"));
@@ -715,7 +715,7 @@ mod tests {
             make_entity("Beta", None),
             make_entity("Gamma", None),
         ];
-        let mut app = App::new(vec![], entities);
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
         app.mode = Mode::EntityPicker {
             input: tui_input::Input::default(),
             matches: vec![0, 1, 2],

--- a/tests/contract/test_thoughts_command.rs
+++ b/tests/contract/test_thoughts_command.rs
@@ -32,12 +32,12 @@ fn test_notes_command_empty_database() {
 }
 
 #[test]
-fn test_notes_command_chronological_order() {
+fn test_notes_command_default_descending_order() {
     let temp_db = setup_temp_db();
 
     // Add thoughts in sequence
     run_wet_command(&["add", "Oldest thought"], Some(&temp_db));
-    std::thread::sleep(std::time::Duration::from_millis(10)); // Ensure different timestamps
+    std::thread::sleep(std::time::Duration::from_millis(10));
     run_wet_command(&["add", "Middle thought"], Some(&temp_db));
     std::thread::sleep(std::time::Duration::from_millis(10));
     run_wet_command(&["add", "Newest thought"], Some(&temp_db));
@@ -46,14 +46,14 @@ fn test_notes_command_chronological_order() {
 
     assert_eq!(result.status, 0, "Command should succeed");
 
-    // Verify chronological order by checking positions
+    // Default order is descending (newest first)
     let stdout = result.stdout;
     let oldest_pos = stdout.find("Oldest thought").expect("Should contain oldest thought");
     let middle_pos = stdout.find("Middle thought").expect("Should contain middle thought");
     let newest_pos = stdout.find("Newest thought").expect("Should contain newest thought");
 
-    assert!(oldest_pos < middle_pos, "Oldest should appear before middle");
-    assert!(middle_pos < newest_pos, "Middle should appear before newest");
+    assert!(newest_pos < middle_pos, "Newest should appear before middle");
+    assert!(middle_pos < oldest_pos, "Middle should appear before oldest");
 }
 
 #[test]

--- a/tests/integration/test_cli_execution.rs
+++ b/tests/integration/test_cli_execution.rs
@@ -1,6 +1,7 @@
 /// Integration tests for CLI execute functions (for coverage)
 use tempfile::TempDir;
 use wetware::cli::{add, delete, thoughts};
+use wetware::models::SortOrder;
 use wetware::services::color_mode::ColorMode;
 
 #[test]
@@ -36,7 +37,7 @@ fn test_notes_execute_empty_db() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = thoughts::execute(&db_path, None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never, SortOrder::Descending);
     assert!(result.is_ok());
 }
 
@@ -50,7 +51,7 @@ fn test_notes_execute_with_notes() {
     add::execute("Second thought".to_string(), None, &db_path).unwrap();
 
     // List them
-    let result = thoughts::execute(&db_path, None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never, SortOrder::Descending);
     assert!(result.is_ok());
 }
 
@@ -65,11 +66,11 @@ fn test_notes_execute_with_entity_filter() {
     add::execute("Email [Sarah] the report".to_string(), None, &db_path).unwrap();
 
     // Filter by Sarah
-    let result = thoughts::execute(&db_path, Some("Sarah"), ColorMode::Never);
+    let result = thoughts::execute(&db_path, Some("Sarah"), ColorMode::Never, SortOrder::Descending);
     assert!(result.is_ok());
 
     // Filter by non-existent entity
-    let result = thoughts::execute(&db_path, Some("NonExistent"), ColorMode::Never);
+    let result = thoughts::execute(&db_path, Some("NonExistent"), ColorMode::Never, SortOrder::Descending);
     assert!(result.is_ok());
 }
 

--- a/tests/integration/test_styled_output.rs
+++ b/tests/integration/test_styled_output.rs
@@ -1,6 +1,7 @@
 /// Integration tests for styled entity output (T030)
 use tempfile::TempDir;
 use wetware::cli::{add, thoughts};
+use wetware::models::SortOrder;
 use wetware::services::color_mode::ColorMode;
 
 #[test]
@@ -12,7 +13,7 @@ fn test_styled_output_with_color_always() {
     add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with colors always on (even though we're not in a TTY)
-    let result = thoughts::execute(&db_path, None, ColorMode::Always);
+    let result = thoughts::execute(&db_path, None, ColorMode::Always, SortOrder::Descending);
     assert!(result.is_ok());
 }
 
@@ -25,7 +26,7 @@ fn test_styled_output_with_color_never() {
     add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with colors disabled
-    let result = thoughts::execute(&db_path, None, ColorMode::Never);
+    let result = thoughts::execute(&db_path, None, ColorMode::Never, SortOrder::Descending);
     assert!(result.is_ok());
 }
 
@@ -38,7 +39,7 @@ fn test_styled_output_with_color_auto() {
     add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
 
     // Execute with auto-detection (will be plain since tests aren't TTY)
-    let result = thoughts::execute(&db_path, None, ColorMode::Auto);
+    let result = thoughts::execute(&db_path, None, ColorMode::Auto, SortOrder::Descending);
     assert!(result.is_ok());
 }
 


### PR DESCRIPTION
## Summary

- Adds `wet config <key> [value]` command mimicking `git config` for reading/setting config values with dotted `section.item` keys
- Introduces `thoughts.order` config key (`ascending`/`descending`, default `descending`) controlling thought listing order in both CLI and TUI
- Moves `SortOrder` from TUI-specific module to shared `models` for reuse across CLI, config, and TUI

## Test plan

- [x] `wet config thoughts.order` prints "descending" on fresh config
- [x] `wet config thoughts.order ascending` sets the value, subsequent get prints "ascending"
- [x] `wet config unknown.key` produces error
- [x] `wet config thoughts.order invalid` produces error listing valid values
- [x] `wet thoughts` lists newest-first by default, oldest-first after setting ascending
- [x] TUI launches with configured sort order, `s` key still toggles
- [x] Existing config files without `[thoughts]` section load with descending default (backward compat)
- [x] All 336 tests pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)