### PR TITLE
feat: add `wet entity rename` command

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,14 @@ Remove a description (use empty string or whitespace):
 wet entity edit rust --description ""
 ```
 
+### Rename an entity
+
+```bash
+wet entity rename rust Rustlang
+```
+
+Rewrites every stored reference to the entity's old name (in thought content and entity descriptions) to the new name. Existing links are preserved.
+
 ## Database
 
 By default, notes are stored in `wetware.db` in the current directory. You can specify a custom database location using the `WETWARE_DB` environment variable:

--- a/specs/010-entity-rename.md
+++ b/specs/010-entity-rename.md
@@ -15,6 +15,7 @@ Allow renaming an entity via `wet entity rename <old-name> <new-name>`. Since en
 - The rename (row update + all content rewrites) is atomic: if any step fails, nothing is changed.
 - Renaming to a name already used by a *different* entity fails with an error; no merge behavior.
 - Renaming to the same name, or only changing casing (e.g. `Sarah` -> `Sarah Smith` vs. `Sarah` -> `SARAH`), succeeds.
+- `new-name` cannot contain `[`, `]`, `(`, or `)` — these are reserved for entity reference syntax and would corrupt bracket markup in rewritten content if allowed through unescaped.
 
 ## Decisions
 
@@ -25,6 +26,7 @@ Allow renaming an entity via `wet entity rename <old-name> <new-name>`. Since en
 - **No persisted alias table**: consistent with the existing design (spec 004) where aliases are purely per-occurrence text, not a stored alternate-name registry. Rename does not introduce one.
 - **No entity-merge functionality**: renaming onto an existing different entity is rejected rather than merging the two entities' thoughts/descriptions together. Out of scope.
 - **Self-rename (casing-only) allowed**: the `entities.name` column is `UNIQUE COLLATE NOCASE`, so a naive collision check against that column would false-positive when renaming `Sarah` -> `SARAH`. The collision check instead compares entity IDs, allowing a row to be renamed to a re-cased version of itself.
+- **Reject bracket/paren characters in `new-name`**: `rewrite_entity_references` interpolates `new_name` directly into `[NewName]`/`(NewName)` bracket syntax. Since `new_name` comes straight from a CLI argument (unlike entity names created via `[Name]` parsing, which structurally can't contain these characters), it must be validated up front — otherwise a name like `Sarah]x` would corrupt previously well-formed bracket references in rewritten content on the next parse.
 
 ## CLI Interface
 

--- a/specs/010-entity-rename.md
+++ b/specs/010-entity-rename.md
@@ -1,0 +1,54 @@
+# 010: Entity Rename
+
+## Summary
+
+Allow renaming an entity via `wet entity rename <old-name> <new-name>`. Since entity references are stored as literal bracket text embedded in thought content and entity descriptions (not as pure foreign-key placeholders), a rename rewrites every stored literal occurrence of the old name to the new name, in addition to updating the entity's own row. `thought_entities` links are keyed by entity ID and are never touched — they remain valid across the rename automatically.
+
+## Requirements
+
+- `wet entity rename <old-name> <new-name>` renames an existing entity, matched case-insensitively on `old-name`.
+- Every thought linked to the entity has literal references to the old name rewritten to the new name:
+  - Bare `[OldName]` becomes `[NewName]`.
+  - Aliased `[Alias](OldName)` becomes `[Alias](NewName)` — only the target is rewritten, the alias/display text is left untouched.
+- Every entity's description (including the renamed entity's own description) that references the old name is rewritten using the same rules.
+- Text where the old name coincidentally appears as someone else's alias *display* text pointing at a different target (e.g. `[Sarah](project-alpha)` when renaming a `Sarah` entity) is left unchanged — it isn't a reference to this entity.
+- The rename (row update + all content rewrites) is atomic: if any step fails, nothing is changed.
+- Renaming to a name already used by a *different* entity fails with an error; no merge behavior.
+- Renaming to the same name, or only changing casing (e.g. `Sarah` -> `Sarah Smith` vs. `Sarah` -> `SARAH`), succeeds.
+
+## Decisions
+
+- **Literal rewrite over alias-preserving rewrite**: on rename, stored text is updated to show the new name everywhere, rather than turning old occurrences into an implicit `[OldName](NewName)` alias. Simpler mental model — text always reflects the current entity name. Considered and rejected the alias-preserving approach (`[Sarah]` -> `[Sarah](Sarah Smith)`) since it would leave stale-looking display text and add complexity for the same end goal (keeping links intact).
+- **Links are never re-derived on rename**: `thought_entities` rows are keyed by `entity_id`, not name, so they already remain valid without any action. The content rewrite exists purely to keep displayed/stored text in sync with the new name and to prevent duplicate-entity creation the next time an affected thought's content is re-parsed (e.g. via `wet edit`, which re-extracts entities by name from content on every content change).
+- **Rewrite scope limited to entity's own thoughts**: only thoughts already linked to the entity (via `thought_entities`) are scanned for text rewriting, not every thought in the database.
+- **All-entity description scan**: unlike thoughts, descriptions are scanned across *all* entities (not just the renamed one), since any entity's description text may reference any other entity.
+- **No persisted alias table**: consistent with the existing design (spec 004) where aliases are purely per-occurrence text, not a stored alternate-name registry. Rename does not introduce one.
+- **No entity-merge functionality**: renaming onto an existing different entity is rejected rather than merging the two entities' thoughts/descriptions together. Out of scope.
+- **Self-rename (casing-only) allowed**: the `entities.name` column is `UNIQUE COLLATE NOCASE`, so a naive collision check against that column would false-positive when renaming `Sarah` -> `SARAH`. The collision check instead compares entity IDs, allowing a row to be renamed to a re-cased version of itself.
+
+## CLI Interface
+
+```
+wet entity rename sarah "Sarah Smith"
+```
+
+Renames the entity currently known as "sarah" (case-insensitive match) to "Sarah Smith", rewriting all thought and description text that references it.
+
+Errors:
+```
+wet entity rename nonexistent "New Name"
+# Error: Entity 'nonexistent' not found
+
+wet entity rename sarah john
+# Error: Entity 'john' already exists
+```
+
+## Edge Cases
+
+- Renaming an entity with no thoughts or descriptions referencing it: succeeds, only the entity row changes.
+- Renaming to the exact same name (no-op): succeeds.
+- Renaming with only a casing change (`Sarah` -> `SARAH`): succeeds, updates `canonical_name`.
+- A thought referencing the entity via an aliased form (`[Alias](sarah)`) has only the target rewritten; the alias display text is preserved verbatim.
+- A thought that happens to contain the old name as alias display text for an *unrelated* entity (`[Sarah](project-alpha)`) is left untouched.
+- An unrelated thought that doesn't reference the entity at all is left byte-identical.
+- Partial failure mid-rewrite (e.g. a storage error) rolls back the entire operation — no thought, description, or the entity row itself is left partially updated.

--- a/src/cli/entity_rename.rs
+++ b/src/cli/entity_rename.rs
@@ -29,6 +29,13 @@ pub fn execute(entity_name: &str, new_name: &str, db_path: &Path) -> Result<(), 
         ));
     }
 
+    if new_name.contains(['[', ']', '(', ')']) {
+        return Err(ThoughtError::InvalidInput(
+            "New entity name cannot contain '[', ']', '(', or ')' (these are reserved for entity reference syntax)"
+                .to_string(),
+        ));
+    }
+
     let mut conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 

--- a/src/cli/entity_rename.rs
+++ b/src/cli/entity_rename.rs
@@ -1,0 +1,79 @@
+/// Entity rename command implementation
+use crate::errors::ThoughtError;
+use crate::services::entity_parser::rewrite_entity_references;
+use crate::storage::connection::get_connection;
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::migrations::run_migrations;
+use crate::storage::thoughts_repository::ThoughtsRepository;
+use std::path::Path;
+
+/// Execute the entity rename command
+///
+/// Renames an entity and rewrites every literal reference to its old name
+/// (in linked thoughts and in any entity's description) to the new name.
+/// `thought_entities` links are keyed by entity ID and are left untouched -
+/// only stored text is rewritten. The whole operation is atomic.
+///
+/// # Arguments
+/// * `entity_name` - Current name of the entity to rename (case-insensitive)
+/// * `new_name` - New name for the entity
+/// * `db_path` - Database path
+///
+/// # Returns
+/// * `Ok(())` - Entity successfully renamed
+/// * `Err(ThoughtError)` - Entity not found, new name already in use, or storage error
+pub fn execute(entity_name: &str, new_name: &str, db_path: &Path) -> Result<(), ThoughtError> {
+    if new_name.trim().is_empty() {
+        return Err(ThoughtError::InvalidInput(
+            "New entity name cannot be empty".to_string(),
+        ));
+    }
+
+    let mut conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let entity = EntitiesRepository::find_by_name(&conn, entity_name)?;
+    let Some(entity) = entity else {
+        eprintln!("Error: Entity '{}' not found", entity_name);
+        eprintln!();
+        eprintln!("Hint: Create the entity first by referencing it in a thought:");
+        eprintln!("  wet add \"Learning about [{}] today\"", entity_name);
+        return Err(ThoughtError::EntityNotFound(entity_name.to_string()));
+    };
+
+    if let Some(existing) = EntitiesRepository::find_by_name(&conn, new_name)?
+        && existing.id != entity.id
+    {
+        eprintln!("Error: Entity '{}' already exists", new_name);
+        return Err(ThoughtError::EntityAlreadyExists(new_name.to_string()));
+    }
+
+    let tx = conn.transaction()?;
+
+    // Rewrite descriptions of every entity (including this one's own) before renaming
+    // the row, since lookups here are still by the pre-rename name.
+    for other in EntitiesRepository::list_all(&tx)? {
+        if let Some(desc) = &other.description {
+            let rewritten = rewrite_entity_references(desc, &entity.name, new_name);
+            if rewritten != *desc {
+                EntitiesRepository::update_description(&tx, &other.name, Some(rewritten))?;
+            }
+        }
+    }
+
+    // Rewrite content of every thought currently linked to this entity.
+    for thought in ThoughtsRepository::list_by_entity(&tx, &entity.name)? {
+        let rewritten = rewrite_entity_references(&thought.content, &entity.name, new_name);
+        if rewritten != thought.content {
+            ThoughtsRepository::update(&tx, thought.id.unwrap(), &rewritten, thought.created_at)?;
+        }
+    }
+
+    EntitiesRepository::rename(&tx, &entity.name, new_name)?;
+
+    tx.commit()?;
+
+    println!("Entity '{}' renamed to '{}'.", entity_name, new_name);
+
+    Ok(())
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod delete;
 pub mod edit;
 pub mod entities;
 pub mod entity_edit;
+pub mod entity_rename;
 pub mod thoughts;
 pub mod tui;
 
@@ -87,5 +88,12 @@ pub enum EntityCommands {
         /// Path to file containing description (mutually exclusive with --description)
         #[arg(long)]
         description_file: Option<std::path::PathBuf>,
+    },
+    /// Rename an entity, rewriting all literal references to it
+    Rename {
+        /// Current entity name (case-insensitive)
+        entity_name: String,
+        /// New entity name
+        new_name: String,
     },
 }

--- a/src/errors/thought_error.rs
+++ b/src/errors/thought_error.rs
@@ -24,6 +24,9 @@ pub enum ThoughtError {
     #[error("Entity '{0}' not found")]
     EntityNotFound(String),
 
+    #[error("Entity '{0}' already exists")]
+    EntityAlreadyExists(String),
+
     #[error("Thought with ID {0} not found")]
     ThoughtNotFound(i64),
 

--- a/src/main.rs
+++ b/src/main.rs
@@ -63,6 +63,9 @@ fn main() {
                 description,
                 description_file,
             } => wetware::cli::entity_edit::execute(&entity_name, description, description_file, &db_path),
+            EntityCommands::Rename { entity_name, new_name } => {
+                wetware::cli::entity_rename::execute(&entity_name, &new_name, &db_path)
+            }
         },
     };
 

--- a/src/services/entity_parser.rs
+++ b/src/services/entity_parser.rs
@@ -1,5 +1,5 @@
 /// Entity parser service - extracts entity references from note text
-use regex::Regex;
+use regex::{Captures, Regex};
 use std::sync::LazyLock;
 
 /// Regex pattern for entity syntax: [entity] or [alias](entity)
@@ -73,6 +73,53 @@ pub fn extract_unique_entities(text: &str) -> Vec<String> {
     }
 
     unique
+}
+
+/// Rewrite literal references to `old_name` (case-insensitive) into `new_name`.
+///
+/// Used when renaming an entity, to keep stored thought/description text in sync
+/// with the entity's new name.
+///
+/// - Bare `[OldName]` -> `[NewName]` (no group 2, display text matches `old_name`)
+/// - Aliased `[Alias](OldName)` -> `[Alias](NewName)` (group 2 matches `old_name`;
+///   the alias/display text in group 1 is left untouched)
+/// - `[Sarah](other-target)` where group 1 happens to equal `old_name` but group 2
+///   is a different target: left untouched (coincidental alias text, not a reference
+///   to this entity)
+/// - Everything else: left untouched
+///
+/// # Examples
+///
+/// ```
+/// use wetware::services::entity_parser::rewrite_entity_references;
+///
+/// let text = rewrite_entity_references("Meeting with [Sarah]", "sarah", "Sarah Smith");
+/// assert_eq!(text, "Meeting with [Sarah Smith]");
+///
+/// let text = rewrite_entity_references("Called [Sarah](sarah) again", "sarah", "Sarah Smith");
+/// assert_eq!(text, "Called [Sarah](Sarah Smith) again");
+/// ```
+pub fn rewrite_entity_references(text: &str, old_name: &str, new_name: &str) -> String {
+    let old_lower = old_name.trim().to_lowercase();
+
+    ENTITY_PATTERN
+        .replace_all(text, |caps: &Captures| {
+            let alias = caps[1].trim();
+            let target = caps.get(2).map(|m| m.as_str().trim());
+
+            match target {
+                Some(t) if !t.is_empty() => {
+                    if t.to_lowercase() == old_lower {
+                        format!("[{}]({})", alias, new_name)
+                    } else {
+                        caps[0].to_string()
+                    }
+                }
+                None if alias.to_lowercase() == old_lower => format!("[{}]", new_name),
+                _ => caps[0].to_string(),
+            }
+        })
+        .into_owned()
 }
 
 #[cfg(test)]
@@ -227,5 +274,62 @@ mod tests {
         assert_eq!(extract_entities("[entity1] [entity2]"), vec!["entity1", "entity2"]);
         assert!(extract_entities("No entities here").is_empty());
         assert!(extract_entities("Empty [] ignored").is_empty());
+    }
+
+    // ========== Entity Rename: rewrite_entity_references Tests ==========
+
+    #[test]
+    fn test_rewrite_bare_single_occurrence() {
+        let text = rewrite_entity_references("Meeting with [Sarah]", "sarah", "Sarah Smith");
+        assert_eq!(text, "Meeting with [Sarah Smith]");
+    }
+
+    #[test]
+    fn test_rewrite_bare_multiple_occurrences() {
+        let text = rewrite_entity_references("[Sarah] met [Sarah] again", "sarah", "Sarah Smith");
+        assert_eq!(text, "[Sarah Smith] met [Sarah Smith] again");
+    }
+
+    #[test]
+    fn test_rewrite_aliased_target_preserves_alias_text() {
+        let text = rewrite_entity_references("Called [Sarah](sarah) again", "sarah", "Sarah Smith");
+        assert_eq!(text, "Called [Sarah](Sarah Smith) again");
+    }
+
+    #[test]
+    fn test_rewrite_aliased_target_different_alias_text() {
+        let text = rewrite_entity_references("Called [my friend](sarah) again", "sarah", "Sarah Smith");
+        assert_eq!(text, "Called [my friend](Sarah Smith) again");
+    }
+
+    #[test]
+    fn test_rewrite_untouched_coincidental_alias_display_text() {
+        // "Sarah" is used here as alias display text for a *different* target entity.
+        let text = rewrite_entity_references("[Sarah](project-alpha)", "sarah", "Sarah Smith");
+        assert_eq!(text, "[Sarah](project-alpha)");
+    }
+
+    #[test]
+    fn test_rewrite_case_insensitive_match() {
+        let text = rewrite_entity_references("[SARAH] and [sarah]", "Sarah", "Sarah Smith");
+        assert_eq!(text, "[Sarah Smith] and [Sarah Smith]");
+    }
+
+    #[test]
+    fn test_rewrite_mixed_bare_and_aliased() {
+        let text = rewrite_entity_references("[Sarah] called [S](sarah)", "sarah", "Sarah Smith");
+        assert_eq!(text, "[Sarah Smith] called [S](Sarah Smith)");
+    }
+
+    #[test]
+    fn test_rewrite_no_match_passthrough() {
+        let text = rewrite_entity_references("Meeting with [John] about [project]", "sarah", "Sarah Smith");
+        assert_eq!(text, "Meeting with [John] about [project]");
+    }
+
+    #[test]
+    fn test_rewrite_unrelated_text_unchanged() {
+        let text = rewrite_entity_references("No entities here at all", "sarah", "Sarah Smith");
+        assert_eq!(text, "No entities here at all");
     }
 }

--- a/src/storage/entities_repository.rs
+++ b/src/storage/entities_repository.rs
@@ -117,6 +117,31 @@ impl EntitiesRepository {
 
         Ok(())
     }
+
+    /// Rename an entity, updating its `name` and `canonical_name`.
+    ///
+    /// Returns the entity's ID on success. Fails with `EntityNotFound` if `old_name`
+    /// doesn't exist, or `EntityAlreadyExists` if `new_name` resolves to a *different*
+    /// existing entity. Renaming to the same entity (no-op, or a casing-only change)
+    /// succeeds, since the collision check compares IDs rather than the name string.
+    pub fn rename(conn: &Connection, old_name: &str, new_name: &str) -> Result<i64, ThoughtError> {
+        let old =
+            Self::find_by_name(conn, old_name)?.ok_or_else(|| ThoughtError::EntityNotFound(old_name.to_string()))?;
+
+        if let Some(existing) = Self::find_by_name(conn, new_name)?
+            && existing.id != old.id
+        {
+            return Err(ThoughtError::EntityAlreadyExists(new_name.to_string()));
+        }
+
+        let id = old.id.unwrap();
+        conn.execute(
+            "UPDATE entities SET name = ?1, canonical_name = ?2 WHERE id = ?3",
+            (new_name.to_lowercase(), new_name, id),
+        )?;
+
+        Ok(id)
+    }
 }
 
 #[cfg(test)]
@@ -305,5 +330,88 @@ mod tests {
             Err(ThoughtError::EntityNotFound(name)) => assert_eq!(name, "nonexistent"),
             _ => panic!("Expected EntityNotFound error"),
         }
+    }
+
+    #[test]
+    fn test_rename_success() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let entity = Entity::new("Sarah".to_string());
+        let id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+
+        let renamed_id = EntitiesRepository::rename(&conn, "sarah", "Sarah Smith").unwrap();
+        assert_eq!(renamed_id, id);
+
+        let found = EntitiesRepository::find_by_name(&conn, "sarah smith").unwrap().unwrap();
+        assert_eq!(found.id, Some(id));
+        assert_eq!(found.canonical_name, "Sarah Smith");
+
+        assert!(EntitiesRepository::find_by_name(&conn, "sarah").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_rename_casing_only_self_rename() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let entity = Entity::new("Sarah".to_string());
+        let id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+
+        let renamed_id = EntitiesRepository::rename(&conn, "Sarah", "SARAH").unwrap();
+        assert_eq!(renamed_id, id);
+
+        let found = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        assert_eq!(found.canonical_name, "SARAH");
+    }
+
+    #[test]
+    fn test_rename_noop_self_rename() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let entity = Entity::new("Sarah".to_string());
+        let id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+
+        let renamed_id = EntitiesRepository::rename(&conn, "Sarah", "Sarah").unwrap();
+        assert_eq!(renamed_id, id);
+
+        let found = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        assert_eq!(found.canonical_name, "Sarah");
+    }
+
+    #[test]
+    fn test_rename_nonexistent_entity() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let result = EntitiesRepository::rename(&conn, "nonexistent", "New Name");
+        assert!(result.is_err());
+        match result {
+            Err(ThoughtError::EntityNotFound(name)) => assert_eq!(name, "nonexistent"),
+            _ => panic!("Expected EntityNotFound error"),
+        }
+    }
+
+    #[test]
+    fn test_rename_collision_with_different_entity() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = Entity::new("Sarah".to_string());
+        let john = Entity::new("John".to_string());
+        EntitiesRepository::find_or_create(&conn, &sarah).unwrap();
+        EntitiesRepository::find_or_create(&conn, &john).unwrap();
+
+        let result = EntitiesRepository::rename(&conn, "sarah", "John");
+        assert!(result.is_err());
+        match result {
+            Err(ThoughtError::EntityAlreadyExists(name)) => assert_eq!(name, "John"),
+            _ => panic!("Expected EntityAlreadyExists error"),
+        }
+
+        // Original entity untouched
+        let found = EntitiesRepository::find_by_name(&conn, "sarah").unwrap();
+        assert!(found.is_some());
     }
 }

--- a/tests/contract/mod.rs
+++ b/tests/contract/mod.rs
@@ -3,4 +3,5 @@ mod test_add_command;
 mod test_edit_command;
 mod test_entities_command;
 mod test_entity_edit_command;
+mod test_entity_rename_command;
 mod test_thoughts_command;

--- a/tests/contract/test_entity_rename_command.rs
+++ b/tests/contract/test_entity_rename_command.rs
@@ -74,3 +74,31 @@ fn test_entity_rename_nonexistent_entity() {
         result.stdout
     );
 }
+
+#[test]
+fn test_entity_rename_rejects_bracket_characters_in_new_name() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+
+    for bad_name in ["Sarah]x", "[Sarah", "Sarah(x)", "Sarah)"] {
+        let result = run_wet_command(&["entity", "rename", "sarah", bad_name], Some(&temp_db));
+
+        assert_ne!(result.status, 0, "Command should fail for new name '{}'", bad_name);
+        assert!(
+            result.stderr.contains("cannot contain") || result.stdout.contains("cannot contain"),
+            "Should show reserved-character error for '{}'. stderr: {}, stdout: {}",
+            bad_name,
+            result.stderr,
+            result.stdout
+        );
+    }
+
+    // Original content must be untouched by the rejected attempts.
+    let thoughts_result = run_wet_command(&["thoughts"], Some(&temp_db));
+    assert!(
+        thoughts_result.stdout.contains("Sarah") && !thoughts_result.stdout.contains("Sarah]x"),
+        "Original content should be unchanged. Got: {}",
+        thoughts_result.stdout
+    );
+}

--- a/tests/contract/test_entity_rename_command.rs
+++ b/tests/contract/test_entity_rename_command.rs
@@ -1,0 +1,76 @@
+/// Contract tests for `wet entity rename` command
+use crate::test_helpers::{run_wet_command, setup_temp_db};
+
+#[test]
+fn test_entity_rename_happy_path() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah] about [project-alpha]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "rename", "sarah", "Sarah Smith"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("Entity 'sarah' renamed to 'Sarah Smith'"),
+        "Should show success message. Got: {}",
+        result.stdout
+    );
+
+    let thoughts_result = run_wet_command(&["thoughts"], Some(&temp_db));
+    assert!(
+        thoughts_result.stdout.contains("Sarah Smith"),
+        "Thought text should reflect new name. Got: {}",
+        thoughts_result.stdout
+    );
+
+    let entities_result = run_wet_command(&["entities"], Some(&temp_db));
+    assert!(
+        entities_result.stdout.contains("Sarah Smith"),
+        "Entities list should show new name. Got: {}",
+        entities_result.stdout
+    );
+
+    let entity_count = entities_result
+        .stdout
+        .lines()
+        .filter(|line| line.to_lowercase().contains("sarah"))
+        .count();
+    assert_eq!(
+        entity_count, 1,
+        "Should be exactly one entity mentioning 'sarah' (no leftover duplicate). Got: {}",
+        entities_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_rename_collision_with_different_entity() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah] and [John]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "rename", "sarah", "John"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("already exists") || result.stdout.contains("already exists"),
+        "Should show collision error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_rename_nonexistent_entity() {
+    let temp_db = setup_temp_db();
+
+    let result = run_wet_command(&["entity", "rename", "nonexistent", "New Name"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("Entity 'nonexistent' not found")
+            || result.stdout.contains("Entity 'nonexistent' not found"),
+        "Should show entity not found error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}

--- a/tests/integration/mod.rs
+++ b/tests/integration/mod.rs
@@ -4,5 +4,6 @@ mod test_description_formatter;
 mod test_edit_atomicity;
 mod test_entity_descriptions;
 mod test_entity_references;
+mod test_entity_rename;
 mod test_styled_output;
 mod test_thought_persistence;

--- a/tests/integration/test_entity_rename.rs
+++ b/tests/integration/test_entity_rename.rs
@@ -1,0 +1,201 @@
+/// Integration tests for entity rename
+///
+/// Verifies that renaming an entity rewrites literal references in linked thoughts
+/// and entity descriptions, leaves unrelated content untouched, and preserves
+/// `thought_entities` links (which are keyed by ID, not name).
+use wetware::errors::ThoughtError;
+use wetware::models::entity::Entity;
+use wetware::models::thought::Thought;
+use wetware::services::entity_parser::rewrite_entity_references;
+use wetware::storage::connection::get_memory_connection;
+use wetware::storage::entities_repository::EntitiesRepository;
+use wetware::storage::migrations::run_migrations;
+use wetware::storage::thoughts_repository::ThoughtsRepository;
+
+/// Mirrors the orchestration in `src/cli/entity_rename.rs`, without going through the CLI,
+/// so the atomicity/rewrite behavior can be exercised directly against an in-memory DB.
+fn rename_entity(conn: &mut rusqlite::Connection, old_name: &str, new_name: &str) -> Result<(), ThoughtError> {
+    let entity = EntitiesRepository::find_by_name(conn, old_name)?.expect("entity should exist");
+
+    let tx = conn.transaction()?;
+
+    for other in EntitiesRepository::list_all(&tx)? {
+        if let Some(desc) = &other.description {
+            let rewritten = rewrite_entity_references(desc, &entity.name, new_name);
+            if rewritten != *desc {
+                EntitiesRepository::update_description(&tx, &other.name, Some(rewritten))?;
+            }
+        }
+    }
+
+    for thought in ThoughtsRepository::list_by_entity(&tx, &entity.name)? {
+        let rewritten = rewrite_entity_references(&thought.content, &entity.name, new_name);
+        if rewritten != thought.content {
+            ThoughtsRepository::update(&tx, thought.id.unwrap(), &rewritten, thought.created_at)?;
+        }
+    }
+
+    EntitiesRepository::rename(&tx, &entity.name, new_name)?;
+
+    tx.commit()?;
+    Ok(())
+}
+
+#[test]
+fn test_rename_rewrites_bare_content() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let thought = Thought::new("Meeting with [Sarah]".to_string()).unwrap();
+    let thought_id = ThoughtsRepository::save(&conn, &thought).unwrap();
+    let entity = Entity::new("Sarah".to_string());
+    let entity_id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+    EntitiesRepository::link_to_thought(&conn, entity_id, thought_id).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    let thought = ThoughtsRepository::get_by_id(&conn, thought_id).unwrap();
+    assert_eq!(thought.content, "Meeting with [Sarah Smith]");
+}
+
+#[test]
+fn test_rename_rewrites_aliased_content_preserving_alias_text() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let thought = Thought::new("Called [Sarah](sarah) again".to_string()).unwrap();
+    let thought_id = ThoughtsRepository::save(&conn, &thought).unwrap();
+    let entity = Entity::new("Sarah".to_string());
+    let entity_id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+    EntitiesRepository::link_to_thought(&conn, entity_id, thought_id).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    let thought = ThoughtsRepository::get_by_id(&conn, thought_id).unwrap();
+    assert_eq!(thought.content, "Called [Sarah](Sarah Smith) again");
+}
+
+#[test]
+fn test_rename_leaves_unrelated_thought_untouched() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let sarah_thought = Thought::new("Meeting with [Sarah]".to_string()).unwrap();
+    let sarah_thought_id = ThoughtsRepository::save(&conn, &sarah_thought).unwrap();
+    let entity = Entity::new("Sarah".to_string());
+    let entity_id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+    EntitiesRepository::link_to_thought(&conn, entity_id, sarah_thought_id).unwrap();
+
+    let unrelated_thought = Thought::new("Unrelated note about [John]".to_string()).unwrap();
+    let unrelated_thought_id = ThoughtsRepository::save(&conn, &unrelated_thought).unwrap();
+    let john = Entity::new("John".to_string());
+    let john_id = EntitiesRepository::find_or_create(&conn, &john).unwrap();
+    EntitiesRepository::link_to_thought(&conn, john_id, unrelated_thought_id).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    let unrelated = ThoughtsRepository::get_by_id(&conn, unrelated_thought_id).unwrap();
+    assert_eq!(unrelated.content, "Unrelated note about [John]");
+}
+
+#[test]
+fn test_rename_preserves_link_by_id() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let thought = Thought::new("Meeting with [Sarah]".to_string()).unwrap();
+    let thought_id = ThoughtsRepository::save(&conn, &thought).unwrap();
+    let entity = Entity::new("Sarah".to_string());
+    let entity_id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+    EntitiesRepository::link_to_thought(&conn, entity_id, thought_id).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    // Querying by the new name must still find the thought - the link is keyed by ID.
+    let thoughts = ThoughtsRepository::list_by_entity(&conn, "sarah smith").unwrap();
+    assert_eq!(thoughts.len(), 1);
+    assert_eq!(thoughts[0].id, Some(thought_id));
+
+    let link_count: i64 = conn
+        .query_row(
+            "SELECT COUNT(*) FROM thought_entities WHERE thought_id = ?1 AND entity_id = ?2",
+            (thought_id, entity_id),
+            |row| row.get(0),
+        )
+        .unwrap();
+    assert_eq!(link_count, 1, "Original link row must be untouched");
+}
+
+#[test]
+fn test_rename_rewrites_other_entitys_description() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let sarah = Entity::new("Sarah".to_string());
+    EntitiesRepository::find_or_create(&conn, &sarah).unwrap();
+
+    let team = Entity::new("Team".to_string());
+    EntitiesRepository::find_or_create(&conn, &team).unwrap();
+    EntitiesRepository::update_description(&conn, "team", Some("Led by [Sarah]".to_string())).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    let team_entity = EntitiesRepository::find_by_name(&conn, "team").unwrap().unwrap();
+    assert_eq!(team_entity.description, Some("Led by [Sarah Smith]".to_string()));
+}
+
+#[test]
+fn test_rename_rewrites_own_description() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let sarah = Entity::new("Sarah".to_string());
+    EntitiesRepository::find_or_create(&conn, &sarah).unwrap();
+    EntitiesRepository::update_description(&conn, "sarah", Some("AKA [Sarah] on the team".to_string())).unwrap();
+
+    rename_entity(&mut conn, "sarah", "Sarah Smith").unwrap();
+
+    let renamed = EntitiesRepository::find_by_name(&conn, "sarah smith").unwrap().unwrap();
+    assert_eq!(renamed.description, Some("AKA [Sarah Smith] on the team".to_string()));
+}
+
+#[test]
+fn test_rename_rollback_on_collision_leaves_everything_unchanged() {
+    let mut conn = get_memory_connection().unwrap();
+    run_migrations(&conn).unwrap();
+
+    let thought = Thought::new("Meeting with [Sarah]".to_string()).unwrap();
+    let thought_id = ThoughtsRepository::save(&conn, &thought).unwrap();
+    let sarah = Entity::new("Sarah".to_string());
+    let sarah_id = EntitiesRepository::find_or_create(&conn, &sarah).unwrap();
+    EntitiesRepository::link_to_thought(&conn, sarah_id, thought_id).unwrap();
+
+    let john = Entity::new("John".to_string());
+    EntitiesRepository::find_or_create(&conn, &john).unwrap();
+
+    // Renaming "sarah" -> "john" should fail outright (collision check happens before
+    // the transaction even opens in the real orchestration); here we call the repository
+    // rename directly inside a transaction to confirm no partial writes occur if it fails
+    // after some rewrites were already staged.
+    let result = (|| -> Result<(), ThoughtError> {
+        let tx = conn.transaction()?;
+        let entity = EntitiesRepository::find_by_name(&tx, "sarah")?.unwrap();
+        for thought in ThoughtsRepository::list_by_entity(&tx, &entity.name)? {
+            let rewritten = rewrite_entity_references(&thought.content, &entity.name, "John");
+            if rewritten != thought.content {
+                ThoughtsRepository::update(&tx, thought.id.unwrap(), &rewritten, thought.created_at)?;
+            }
+        }
+        EntitiesRepository::rename(&tx, &entity.name, "John")?;
+        tx.commit()?;
+        Ok(())
+    })();
+
+    assert!(result.is_err());
+
+    // Nothing should have been persisted: the thought content is unchanged (the
+    // transaction was rolled back on Drop before commit).
+    let thought = ThoughtsRepository::get_by_id(&conn, thought_id).unwrap();
+    assert_eq!(thought.content, "Meeting with [Sarah]");
+    assert!(EntitiesRepository::find_by_name(&conn, "sarah").unwrap().is_some());
+}


### PR DESCRIPTION
## Summary
- Adds `wet entity rename <old-name> <new-name>` to rename an entity.
- Since entity references are stored as literal bracket text in thought content and entity descriptions (not pure foreign keys), rename rewrites every stored reference to the old name — bare `[Old]` → `[New]`, and aliased `[Alias](Old)` → `[Alias](New)` (alias text preserved). `thought_entities` links are keyed by entity ID and are never touched.
- The whole operation (row rename + all rewrites) runs in a single transaction, so a failure can't leave things half-updated. Renaming onto an existing different entity is rejected (no merge); casing-only self-renames are allowed.
- See `specs/010-entity-rename.md` for full requirements/decisions.

## Test plan
- [x] `cargo nextest run` — 360/360 passed
- [x] `cargo clippy --all-targets` — no new warnings introduced
- [x] `cargo fmt --check` — clean
- [x] Manual smoke test: renamed an entity referenced both bare and via alias across two thoughts, confirmed both thoughts render the new name, confirmed no duplicate entity is created when re-editing an affected thought afterward

🤖 Generated with [Claude Code](https://claude.com/claude-code)