### PR TITLE
feat: add `wet entity show` command

### DIFF
--- a/specs/011-entity-show.md
+++ b/specs/011-entity-show.md
@@ -1,0 +1,73 @@
+# 011: Entity Show
+
+## Summary
+
+Allow viewing a single entity's detail via `wet entity show <name>`: the entity's full description, styled the same way entity references are styled in thought content (consistent colors, aliases rendered as their display text), followed by the 5 most recent thoughts linked to the entity.
+
+## Requirements
+
+- `wet entity show <name>` displays an entity matched case-insensitively on `name`.
+- Errors with `Entity '<name>' not found` if no such entity exists.
+- Displays the entity's canonical name as a header.
+- If the entity has a description, displays it in full (all paragraphs, not just the first) with entity references rendered using the same styling rules as thought content: consistent per-entity colors, bold text, aliased references (`[alias](entity)`) shown as their alias display text rather than the target entity name. Colors are consistent between the description and the thoughts list below (same entity gets the same color in both).
+- If the entity has no description, the description section is omitted entirely (no placeholder text).
+- Displays up to 5 most recently created thoughts linked to the entity, newest first, in the same `[id] date - content` format used by `wet thoughts`, with entity references styled the same way.
+- If the entity has no linked thoughts, displays a message instead of the list.
+- Respects the same `--color` flag semantics as `wet thoughts` (auto/always/never).
+
+## Decisions
+
+- **Full description, not a preview**: unlike `wet entities` (spec 002), which shows a single-line ellipsized first-paragraph preview with plain (unstyled) entity references, `wet entity show` is a detail view and renders the complete description with full entity styling. `services::description_formatter::generate_preview` is not used here.
+- **Newest-first, limit 5**: a dedicated repository query (`ThoughtsRepository::list_latest_by_entity`) orders by `created_at DESC` and limits in SQL, rather than fetching all of an entity's thoughts and truncating in the CLI layer.
+- **Shared `EntityStyler` instance**: one styler is used across both the description and the thoughts list so that entity color assignment stays consistent within a single invocation, matching how `wet thoughts` assigns colors consistently across all printed thoughts.
+
+## CLI Interface
+
+```
+wet entity show rust
+```
+
+```
+Rust
+
+Rust is a systems programming language focused on safety, particularly memory
+safety, while maintaining performance. See also related work in ML.
+
+Latest thoughts:
+[42] 2026-07-10 - Started reading the Rust book again
+[31] 2026-05-02 - Rust's borrow checker finally clicked today
+```
+
+(`ML` above renders as a styled alias for a `machine-learning` entity reference in the description, e.g. from `[ML](machine-learning)`.)
+
+No description:
+```
+wet entity show wetware
+```
+```
+wetware
+
+Latest thoughts:
+[12] 2026-06-01 - Added entity show command
+```
+
+Entity with no thoughts:
+```
+Latest thoughts:
+No thoughts found for entity: wetware
+```
+
+Errors:
+```
+wet entity show nonexistent
+# Error: Entity 'nonexistent' not found
+```
+
+## Edge Cases
+
+- Entity has a description but zero linked thoughts: description prints in full, followed by the "no thoughts" message.
+- Entity has thoughts but no description: description section omitted, thoughts list still prints.
+- Entity has fewer than 5 thoughts: all of them print, newest first.
+- Entity has more than 5 thoughts: only the 5 most recent print.
+- Description spans multiple paragraphs: all paragraphs are printed (no first-paragraph truncation, unlike the `wet entities` preview).
+- Description or thought content contains aliased entity references (`[alias](entity)`): the alias display text is shown, colored by the target entity, matching `wet thoughts` rendering rules.

--- a/src/cli/entity_show.rs
+++ b/src/cli/entity_show.rs
@@ -1,0 +1,111 @@
+/// Entity show command implementation
+use crate::errors::ThoughtError;
+use crate::services::color_mode::ColorMode;
+use crate::services::entity_styler::EntityStyler;
+use crate::storage::connection::get_connection;
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::migrations::run_migrations;
+use crate::storage::thoughts_repository::ThoughtsRepository;
+use std::path::Path;
+
+/// Number of most recent thoughts to display for the entity
+const LATEST_THOUGHTS_LIMIT: usize = 5;
+
+/// Execute the entity show command
+///
+/// Displays an entity's full description (styled consistently with thought content,
+/// with entity references colored and aliases rendered as their display text) followed
+/// by the 5 most recent thoughts linked to the entity.
+///
+/// # Arguments
+/// * `entity_name` - Name of the entity to show (case-insensitive)
+/// * `db_path` - Database path
+/// * `color_mode` - Whether to apply ANSI styling to entity references
+///
+/// # Returns
+/// * `Ok(())` - Success
+/// * `Err(ThoughtError::EntityNotFound)` - No entity with the given name exists
+pub fn execute(entity_name: &str, db_path: &Path, color_mode: ColorMode) -> Result<(), ThoughtError> {
+    let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let entity = EntitiesRepository::find_by_name(&conn, entity_name)?
+        .ok_or_else(|| ThoughtError::EntityNotFound(entity_name.to_string()))?;
+
+    let mut styler = EntityStyler::new(color_mode.should_use_colors());
+
+    println!("{}", entity.canonical_name);
+
+    if let Some(description) = &entity.description {
+        println!();
+        println!("{}", styler.render_content(description));
+    }
+
+    println!();
+    println!("Latest thoughts:");
+
+    let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, entity_name, LATEST_THOUGHTS_LIMIT)?;
+
+    if thoughts.is_empty() {
+        println!("No thoughts found for entity: {}", entity.canonical_name);
+    } else {
+        for thought in thoughts {
+            let styled_content = styler.render_content(thought.content.trim());
+            println!(
+                "[{}] {} - {}",
+                thought.id.unwrap_or(0),
+                thought.created_at.format("%Y-%m-%d"),
+                styled_content
+            );
+        }
+    }
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::entity::Entity;
+    use crate::storage::connection::get_memory_connection;
+    use rusqlite::Connection;
+
+    fn setup_entity(conn: &Connection, name: &str, description: Option<&str>) {
+        let entity = Entity::new(name.to_string());
+        EntitiesRepository::find_or_create(conn, &entity).unwrap();
+        if let Some(desc) = description {
+            EntitiesRepository::update_description(conn, name, Some(desc.to_string())).unwrap();
+        }
+    }
+
+    #[test]
+    fn test_entity_not_found_returns_error() {
+        let conn = get_memory_connection().unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        let result = EntitiesRepository::find_by_name(&conn, "nonexistent").unwrap();
+        assert!(result.is_none());
+    }
+
+    #[test]
+    fn test_entity_without_description_has_none() {
+        let conn = get_memory_connection().unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        setup_entity(&conn, "rust", None);
+
+        let entity = EntitiesRepository::find_by_name(&conn, "rust").unwrap().unwrap();
+        assert!(entity.description.is_none());
+    }
+
+    #[test]
+    fn test_entity_with_description_is_returned() {
+        let conn = get_memory_connection().unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        setup_entity(&conn, "rust", Some("A systems programming language."));
+
+        let entity = EntitiesRepository::find_by_name(&conn, "rust").unwrap().unwrap();
+        assert_eq!(entity.description.as_deref(), Some("A systems programming language."));
+    }
+}

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -6,6 +6,7 @@ pub mod edit;
 pub mod entities;
 pub mod entity_edit;
 pub mod entity_rename;
+pub mod entity_show;
 pub mod thoughts;
 pub mod tui;
 
@@ -95,5 +96,10 @@ pub enum EntityCommands {
         entity_name: String,
         /// New entity name
         new_name: String,
+    },
+    /// Show an entity's description and latest thoughts
+    Show {
+        /// Entity name (case-insensitive)
+        entity_name: String,
     },
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -66,6 +66,9 @@ fn main() {
             EntityCommands::Rename { entity_name, new_name } => {
                 wetware::cli::entity_rename::execute(&entity_name, &new_name, &db_path)
             }
+            EntityCommands::Show { entity_name } => {
+                wetware::cli::entity_show::execute(&entity_name, &db_path, cli.color)
+            }
         },
     };
 

--- a/src/storage/thoughts_repository.rs
+++ b/src/storage/thoughts_repository.rs
@@ -133,6 +133,44 @@ impl ThoughtsRepository {
 
         Ok(thoughts)
     }
+
+    /// List the most recent thoughts linked to an entity (case-insensitive), newest first
+    pub fn list_latest_by_entity(
+        conn: &Connection,
+        entity_name: &str,
+        limit: usize,
+    ) -> Result<Vec<Thought>, ThoughtError> {
+        let lowercase_name = entity_name.to_lowercase();
+
+        let mut stmt = conn.prepare(
+            "SELECT DISTINCT t.id, t.content, t.created_at
+             FROM thoughts t
+             INNER JOIN thought_entities te ON t.id = te.thought_id
+             INNER JOIN entities e ON te.entity_id = e.id
+             WHERE e.name = ?1
+             ORDER BY t.created_at DESC
+             LIMIT ?2",
+        )?;
+
+        let thoughts = stmt
+            .query_map((lowercase_name, limit as i64), |row| {
+                let created_at_str: String = row.get(2)?;
+                let created_at = DateTime::parse_from_rfc3339(&created_at_str)
+                    .map_err(|e| {
+                        rusqlite::Error::FromSqlConversionFailure(2, rusqlite::types::Type::Text, Box::new(e))
+                    })?
+                    .with_timezone(&Utc);
+
+                Ok(Thought {
+                    id: Some(row.get(0)?),
+                    content: row.get(1)?,
+                    created_at,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(thoughts)
+    }
 }
 
 #[cfg(test)]
@@ -297,5 +335,91 @@ mod tests {
         assert_eq!(thoughts.len(), 2);
         assert_eq!(thoughts[0].content, "First");
         assert_eq!(thoughts[1].content, "Second");
+    }
+
+    /// Save a thought with the given content, link it to `entity_name` (creating the
+    /// entity if needed), and set its `created_at` explicitly so ordering is deterministic.
+    fn save_linked_thought(conn: &Connection, content: &str, entity_name: &str, created_at: DateTime<Utc>) -> i64 {
+        use crate::models::entity::Entity;
+        use crate::storage::entities_repository::EntitiesRepository;
+
+        let thought = Thought::new(content.to_string()).unwrap();
+        let thought_id = ThoughtsRepository::save(conn, &thought).unwrap();
+        ThoughtsRepository::update(conn, thought_id, content, created_at).unwrap();
+
+        let entity = Entity::new(entity_name.to_string());
+        let entity_id = EntitiesRepository::find_or_create(conn, &entity).unwrap();
+        EntitiesRepository::link_to_thought(conn, entity_id, thought_id).unwrap();
+
+        thought_id
+    }
+
+    fn day(offset: i64) -> DateTime<Utc> {
+        use chrono::Duration;
+        Utc::now() + Duration::days(offset)
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_orders_newest_first() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "Oldest", "rust", day(-2));
+        save_linked_thought(&conn, "Middle", "rust", day(-1));
+        save_linked_thought(&conn, "Newest", "rust", day(0));
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "rust", 5).unwrap();
+        assert_eq!(thoughts.len(), 3);
+        assert_eq!(thoughts[0].content, "Newest");
+        assert_eq!(thoughts[1].content, "Middle");
+        assert_eq!(thoughts[2].content, "Oldest");
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_respects_limit() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        for i in 0..7 {
+            save_linked_thought(&conn, &format!("Thought {i}"), "rust", day(i));
+        }
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "rust", 5).unwrap();
+        assert_eq!(thoughts.len(), 5);
+        assert_eq!(thoughts[0].content, "Thought 6");
+        assert_eq!(thoughts[4].content, "Thought 2");
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_fewer_than_limit_returns_all() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "Only one", "rust", day(0));
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "rust", 5).unwrap();
+        assert_eq!(thoughts.len(), 1);
+        assert_eq!(thoughts[0].content, "Only one");
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_no_thoughts_returns_empty() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "nonexistent", 5).unwrap();
+        assert!(thoughts.is_empty());
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_case_insensitive() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "About Rust", "Rust", day(0));
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "RUST", 5).unwrap();
+        assert_eq!(thoughts.len(), 1);
+        assert_eq!(thoughts[0].content, "About Rust");
     }
 }

--- a/tests/contract/mod.rs
+++ b/tests/contract/mod.rs
@@ -4,4 +4,5 @@ mod test_edit_command;
 mod test_entities_command;
 mod test_entity_edit_command;
 mod test_entity_rename_command;
+mod test_entity_show_command;
 mod test_thoughts_command;

--- a/tests/contract/test_entity_show_command.rs
+++ b/tests/contract/test_entity_show_command.rs
@@ -1,0 +1,173 @@
+/// Contract tests for `wet entity show` command
+use crate::test_helpers::{run_wet_command, setup_temp_db};
+
+#[test]
+fn test_entity_show_entity_not_found() {
+    let temp_db = setup_temp_db();
+
+    let result = run_wet_command(&["entity", "show", "nonexistent"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail for nonexistent entity");
+    assert!(
+        result.stderr.contains("not found"),
+        "Should report entity not found. Got: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn test_entity_show_without_description() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "show", "sarah"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(result.stdout.contains("Sarah"), "Should show entity header");
+    assert!(
+        result.stdout.contains("Latest thoughts:"),
+        "Should show thoughts section header"
+    );
+    assert!(
+        result.stdout.contains("Meeting with Sarah"),
+        "Should list the linked thought. Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_show_with_full_multi_paragraph_description() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [rust]"], Some(&temp_db));
+    run_wet_command(
+        &[
+            "entity",
+            "edit",
+            "rust",
+            "--description",
+            "First paragraph about rust.\n\nSecond paragraph about rust.",
+        ],
+        Some(&temp_db),
+    );
+
+    let result = run_wet_command(&["entity", "show", "rust"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("First paragraph about rust."),
+        "Should show first paragraph. Got: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("Second paragraph about rust."),
+        "Should show second paragraph in full (not truncated like the `entities` preview). Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_show_no_thoughts() {
+    let temp_db = setup_temp_db();
+
+    // Referencing `orphan-entity` in another entity's description auto-creates it
+    // (per entity_edit's auto-creation of referenced entities) without linking it
+    // to any thought, giving us an entity with zero linked thoughts to test against.
+    run_wet_command(&["add", "Meeting with [rust]"], Some(&temp_db));
+    run_wet_command(
+        &["entity", "edit", "rust", "--description", "See also [orphan-entity]"],
+        Some(&temp_db),
+    );
+
+    let result = run_wet_command(&["entity", "show", "orphan-entity"], Some(&temp_db));
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("orphan-entity"),
+        "Should show header. Got: {}",
+        result.stdout
+    );
+    assert!(
+        result.stdout.contains("No thoughts found for entity"),
+        "Should show no-thoughts message. Got: {}",
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_show_latest_five_thoughts_newest_first() {
+    let temp_db = setup_temp_db();
+
+    for i in 1..=7 {
+        run_wet_command(
+            &[
+                "add",
+                &format!("Thought number {i} about [rust]"),
+                "--date",
+                &format!("2026-01-{:02}", i),
+            ],
+            Some(&temp_db),
+        );
+    }
+
+    let result = run_wet_command(&["entity", "show", "rust"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+
+    // Only the 5 most recent (numbers 3-7) should be shown
+    for i in 3..=7 {
+        assert!(
+            result.stdout.contains(&format!("Thought number {i}")),
+            "Should contain thought number {i}. Got: {}",
+            result.stdout
+        );
+    }
+    for i in 1..=2 {
+        assert!(
+            !result.stdout.contains(&format!("Thought number {i} ")),
+            "Should not contain older thought number {i}. Got: {}",
+            result.stdout
+        );
+    }
+
+    // Newest first
+    let newest_pos = result.stdout.find("Thought number 7").unwrap();
+    let oldest_shown_pos = result.stdout.find("Thought number 3").unwrap();
+    assert!(newest_pos < oldest_shown_pos, "Thoughts should be newest first");
+}
+
+#[test]
+fn test_entity_show_color_always_styles_description_and_thoughts_consistently() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(
+        &["add", "First thought referencing [rust] the language"],
+        Some(&temp_db),
+    );
+    run_wet_command(
+        &[
+            "entity",
+            "edit",
+            "rust",
+            "--description",
+            "See also [ML](machine-learning) for related work.",
+        ],
+        Some(&temp_db),
+    );
+
+    let result = run_wet_command(&["--color=always", "entity", "show", "rust"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains('\x1b'),
+        "Should contain ANSI escape codes with --color=always. Got: {:?}",
+        result.stdout
+    );
+    // Alias display text shown, not the target entity name
+    assert!(result.stdout.contains("ML"), "Should show alias display text");
+    assert!(
+        !result.stdout.contains("[ML](machine-learning)"),
+        "Should not contain raw markup. Got: {}",
+        result.stdout
+    );
+}


### PR DESCRIPTION
## Summary
- Add `wet entity show <name>` to display an entity's full description and its 5 most recent thoughts
- Description is rendered in full (all paragraphs) with entity references styled the same way as thought content — consistent colors, aliases shown as their display text
- New `ThoughtsRepository::list_latest_by_entity` fetches the newest N thoughts for an entity directly via SQL `ORDER BY ... DESC LIMIT`

## Test plan
- [x] `cargo test` (unit, contract, integration, doc tests) all passing
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: description + thoughts, entity with no description, entity with no thoughts, nonexistent entity error

🤖 Generated with [Claude Code](https://claude.com/claude-code)