### PR TITLE
feat: add directed parent/child relations between entities

### DIFF
--- a/specs/012-entity-relations.md
+++ b/specs/012-entity-relations.md
@@ -1,0 +1,67 @@
+# 012: Entity Relations
+
+## Summary
+
+Allow directed parent/child relations between entities (e.g. AWS is a child of Amazon), via `wet entity relate <name> --parent <parent>` and `wet entity unrelate <name> --parent <parent>`. Relations form a DAG — an entity may have multiple parents. Filtering thoughts by an entity anywhere in the app (`wet thoughts --on <name>`, `wet entity show <name>`, and the TUI's entity-picker filter) includes thoughts for that entity and every entity transitively reachable from it via child relations (its descendants), so a user filtering on a broad entity automatically sees thoughts tagged only with a more specific descendant.
+
+## Requirements
+
+- `wet entity relate <entity-name> --parent <parent-name>` marks `entity-name` as a child of `parent-name`. Both entities must already exist (matched case-insensitively); if either doesn't, errors with `Entity '<name>' not found` plus a hint to create it via `wet add "...[name]..."`.
+- `wet entity unrelate <entity-name> --parent <parent-name>` removes that relation. Both entities must still exist. Idempotent: succeeds even if the relation didn't exist.
+- Relating an entity to a parent it's already related to succeeds without error (idempotent).
+- An entity cannot be related to itself (`entity-name` == `parent-name`, case-insensitive) — rejected.
+- An entity may have more than one parent (DAG, not a strict tree).
+- Adding a relation that would create a cycle (i.e. the proposed parent is already a descendant of the entity) is rejected — no partial state change.
+- `wet thoughts --on <name>`, the thought list in `wet entity show <name>`, and the TUI entity-picker filter all include thoughts linked to `<name>` and to every entity transitively reachable from it via child relations.
+- `wet entity show <name>` displays direct (non-transitive) `Parents:` and `Children:` lines when the entity has any, omitted entirely when it has none.
+
+## Decisions
+
+- **DAG, not a tree**: an entity may have multiple parents (e.g. "Amazon Leo" could be a child of both "Amazon" and "satellite connectivity domain"). Modeled as a plain edge table rather than a single nullable `parent_id` column on `entities`.
+- **Recursive CTE for reachability, not a materialized closure table**: SQLite's `WITH RECURSIVE` computes descendants on read, avoiding the complexity of maintaining a separate transitive-closure table on every write. At this project's scale (personal notes, not a large graph) the recursive query is fast and requires no rebalancing.
+- **Reachability query lives in `ThoughtsRepository`**: `list_by_entity`/`list_latest_by_entity` inline the recursive CTE directly (root entity + descendants) rather than resolving a descendant-id list in a separate round trip and binding a dynamic `IN (...)` list. This keeps both call sites (`wet thoughts --on`, `wet entity show`) reachability-aware automatically, with no CLI-layer changes.
+- **Dedicated `EntityRelationsRepository` and `entity_relations` table**: kept separate from `EntitiesRepository`/`entities`, mirroring how `thought_entities` is a distinct concern from `thoughts`/`entities` themselves. Keeps the graph-traversal SQL colocated and independently testable.
+- **Cycle check happens application-side (in the CLI command), not via a DB trigger**: `EntityRelationsRepository::would_create_cycle` is a reusable primitive the CLI calls before inserting; `add_relation` itself never validates, matching the "dumb insert" style of `EntitiesRepository::link_to_thought`.
+- **`unrelate` is idempotent/no-op-safe**: removing a relation that doesn't exist succeeds silently, matching `EntitiesRepository::unlink_all_from_thought`'s no-op style, rather than erroring.
+- **Both entities must already exist for `relate`/`unrelate`**: consistent with `entity rename`/`entity show`, which require the entity to already exist rather than auto-creating it. Keeps `relate` focused on linking, not entity creation.
+- **`entity_relate.rs` holds both `execute_relate` and `execute_unrelate`**: unlike the one-file-per-command precedent (`entity_rename.rs`, `entity_show.rs`), these two operations are small, symmetric, and share entity-resolution logic, so splitting them into separate files would only duplicate that logic.
+- **TUI filtering stays in-memory**: the TUI doesn't re-query the database per keystroke; it loads the full relation-edge list once at startup (alongside thoughts/entities) and computes the reachable descendant-name set once when an entity is picked, rather than querying on every filter recomputation.
+
+## CLI Interface
+
+```
+wet entity relate aws --parent amazon
+# Entity 'aws' is now a child of 'amazon'.
+
+wet entity relate "amazon leo" --parent "satellite connectivity domain"
+# Entity 'amazon leo' is now a child of 'satellite connectivity domain'.
+
+wet entity unrelate aws --parent amazon
+# Removed 'aws' as a child of 'amazon'.
+
+wet thoughts --on amazon
+# includes thoughts tagged only [aws], not just thoughts tagged [amazon]
+```
+
+Errors:
+```
+wet entity relate aws --parent nonexistent
+# Error: Entity 'nonexistent' not found
+
+wet entity relate amazon --parent amazon
+# Error: An entity cannot be its own parent: 'amazon'
+
+wet entity relate amazon --parent aws   # (aws already a child of amazon)
+# Error: Cannot make 'amazon' a child of 'aws': 'aws' is already a descendant of 'amazon' (would create a cycle)
+```
+
+## Edge Cases
+
+- Entity with no relations at all: filtering by it behaves exactly as before this feature (regression guard).
+- Diamond-shaped DAG (an entity reachable from the filtered root via two different parent paths): its thoughts appear once in results, not duplicated.
+- Relating an already-related pair: succeeds, no duplicate edge created.
+- Filtering by the root entity itself still includes the root's own thoughts, not just descendants'.
+- Filtering by an unknown entity name still returns an empty result, not an error (unchanged from pre-feature behavior).
+- `wet entity show` on an entity with parents but no children (or vice versa) prints only the applicable line.
+- Long transitive cycles (not just direct A->B->A) are still correctly rejected, since the cycle check follows the same recursive reachability traversal as filtering.
+- No `entity delete` command exists yet; `entity_relations` rows use `ON DELETE CASCADE` on both `child_id` and `parent_id` so they clean up automatically if deletion is ever added.

--- a/src/cli/entity_relate.rs
+++ b/src/cli/entity_relate.rs
@@ -1,0 +1,320 @@
+/// Entity relate/unrelate command implementations
+use crate::errors::ThoughtError;
+use crate::storage::connection::get_connection;
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_relations_repository::EntityRelationsRepository;
+use crate::storage::migrations::run_migrations;
+use rusqlite::Connection;
+use std::path::Path;
+
+fn resolve_entity(conn: &Connection, name: &str) -> Result<crate::models::entity::Entity, ThoughtError> {
+    let entity = EntitiesRepository::find_by_name(conn, name)?;
+    entity.ok_or_else(|| {
+        eprintln!("Error: Entity '{}' not found", name);
+        eprintln!();
+        eprintln!("Hint: Create the entity first by referencing it in a thought:");
+        eprintln!("  wet add \"Learning about [{}] today\"", name);
+        ThoughtError::EntityNotFound(name.to_string())
+    })
+}
+
+/// Execute the entity relate command
+///
+/// Marks `entity_name` as a child of `parent_name`. Both entities must already exist.
+/// Idempotent: relating an already-related pair succeeds without error. Rejects
+/// self-relation and any relation that would create a cycle in the parent/child graph.
+///
+/// # Arguments
+/// * `entity_name` - Entity to mark as a child (case-insensitive)
+/// * `parent_name` - Parent entity name (case-insensitive)
+/// * `db_path` - Database path
+pub fn execute_relate(entity_name: &str, parent_name: &str, db_path: &Path) -> Result<(), ThoughtError> {
+    let mut conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let child = resolve_entity(&conn, entity_name)?;
+    let parent = resolve_entity(&conn, parent_name)?;
+
+    if child.id == parent.id {
+        return Err(ThoughtError::SelfRelation(entity_name.to_string()));
+    }
+
+    let tx = conn.transaction()?;
+
+    if EntityRelationsRepository::would_create_cycle(&tx, child.id.unwrap(), parent.id.unwrap())? {
+        return Err(ThoughtError::RelationCycle {
+            child: child.canonical_name,
+            parent: parent.canonical_name,
+        });
+    }
+
+    EntityRelationsRepository::add_relation(&tx, child.id.unwrap(), parent.id.unwrap())?;
+
+    tx.commit()?;
+
+    println!("Entity '{}' is now a child of '{}'.", entity_name, parent_name);
+
+    Ok(())
+}
+
+/// Execute the entity unrelate command
+///
+/// Removes the child/parent relation between `entity_name` and `parent_name`. Both
+/// entities must already exist. Idempotent: succeeds even if the relation didn't exist.
+///
+/// # Arguments
+/// * `entity_name` - Child entity name (case-insensitive)
+/// * `parent_name` - Parent entity name (case-insensitive)
+/// * `db_path` - Database path
+pub fn execute_unrelate(entity_name: &str, parent_name: &str, db_path: &Path) -> Result<(), ThoughtError> {
+    let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let child = resolve_entity(&conn, entity_name)?;
+    let parent = resolve_entity(&conn, parent_name)?;
+
+    EntityRelationsRepository::remove_relation(&conn, child.id.unwrap(), parent.id.unwrap())?;
+
+    println!("Removed '{}' as a child of '{}'.", entity_name, parent_name);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::entity::Entity;
+    use crate::storage::connection::get_memory_connection;
+
+    fn setup_entity(conn: &Connection, name: &str) {
+        let entity = Entity::new(name.to_string());
+        EntitiesRepository::find_or_create(conn, &entity).unwrap();
+    }
+
+    fn relate_in_memory(child: &str, parent: &str) -> (Connection, Result<(), ThoughtError>) {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, child);
+        setup_entity(&conn, parent);
+
+        let child_entity = EntitiesRepository::find_by_name(&conn, child).unwrap().unwrap();
+        let parent_entity = EntitiesRepository::find_by_name(&conn, parent).unwrap().unwrap();
+
+        if child_entity.id == parent_entity.id {
+            return (conn, Err(ThoughtError::SelfRelation(child.to_string())));
+        }
+
+        let would_cycle =
+            EntityRelationsRepository::would_create_cycle(&conn, child_entity.id.unwrap(), parent_entity.id.unwrap())
+                .unwrap();
+        if would_cycle {
+            return (
+                conn,
+                Err(ThoughtError::RelationCycle {
+                    child: child_entity.canonical_name,
+                    parent: parent_entity.canonical_name,
+                }),
+            );
+        }
+
+        let result =
+            EntityRelationsRepository::add_relation(&conn, child_entity.id.unwrap(), parent_entity.id.unwrap());
+        (conn, result)
+    }
+
+    #[test]
+    fn test_relate_creates_relation() {
+        let (conn, result) = relate_in_memory("AWS", "Amazon");
+        assert!(result.is_ok());
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].canonical_name, "AWS");
+    }
+
+    #[test]
+    fn test_relate_self_relation_rejected() {
+        let (_conn, result) = relate_in_memory("Amazon", "Amazon");
+        assert!(matches!(result, Err(ThoughtError::SelfRelation(_))));
+    }
+
+    #[test]
+    fn test_relate_cycle_rejected() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        setup_entity(&conn, "AWS");
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+
+        EntityRelationsRepository::add_relation(&conn, aws.id.unwrap(), amazon.id.unwrap()).unwrap();
+
+        let would_cycle =
+            EntityRelationsRepository::would_create_cycle(&conn, amazon.id.unwrap(), aws.id.unwrap()).unwrap();
+        assert!(would_cycle);
+    }
+
+    #[test]
+    fn test_relate_idempotent() {
+        let (conn, first) = relate_in_memory("AWS", "Amazon");
+        assert!(first.is_ok());
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+
+        let second = EntityRelationsRepository::add_relation(&conn, aws.id.unwrap(), amazon.id.unwrap());
+        assert!(second.is_ok());
+
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert_eq!(children.len(), 1);
+    }
+
+    #[test]
+    fn test_unrelate_removes_relation() {
+        let (conn, result) = relate_in_memory("AWS", "Amazon");
+        assert!(result.is_ok());
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+
+        EntityRelationsRepository::remove_relation(&conn, aws.id.unwrap(), amazon.id.unwrap()).unwrap();
+
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[test]
+    fn test_unrelate_nonexistent_relation_is_noop() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        setup_entity(&conn, "AWS");
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+
+        let result = EntityRelationsRepository::remove_relation(&conn, aws.id.unwrap(), amazon.id.unwrap());
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_execute_relate_end_to_end() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        setup_entity(&conn, "AWS");
+        drop(conn);
+
+        let result = execute_relate("AWS", "Amazon", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].canonical_name, "AWS");
+    }
+
+    #[test]
+    fn test_execute_relate_missing_child_errors() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        drop(conn);
+
+        let result = execute_relate("AWS", "Amazon", &db_path);
+        assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "AWS"));
+    }
+
+    #[test]
+    fn test_execute_relate_missing_parent_errors() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "AWS");
+        drop(conn);
+
+        let result = execute_relate("AWS", "Amazon", &db_path);
+        assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "Amazon"));
+    }
+
+    #[test]
+    fn test_execute_relate_cycle_rolls_back() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        setup_entity(&conn, "AWS");
+        drop(conn);
+
+        execute_relate("AWS", "Amazon", &db_path).unwrap();
+
+        let result = execute_relate("Amazon", "AWS", &db_path);
+        assert!(matches!(result, Err(ThoughtError::RelationCycle { .. })));
+
+        let conn = get_connection(&db_path).unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+        let amazon_parents = EntityRelationsRepository::list_parents(&conn, aws.id.unwrap()).unwrap();
+        assert_eq!(amazon_parents.len(), 1);
+        assert_eq!(amazon_parents[0].canonical_name, "Amazon");
+    }
+
+    #[test]
+    fn test_execute_unrelate_end_to_end() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        setup_entity(&conn, "AWS");
+        drop(conn);
+
+        execute_relate("AWS", "Amazon", &db_path).unwrap();
+        let result = execute_unrelate("AWS", "Amazon", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[test]
+    fn test_execute_unrelate_requires_both_entities_to_exist() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        setup_entity(&conn, "Amazon");
+        drop(conn);
+
+        let result = execute_unrelate("AWS", "Amazon", &db_path);
+        assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "AWS"));
+    }
+}

--- a/src/cli/entity_relate.rs
+++ b/src/cli/entity_relate.rs
@@ -84,133 +84,33 @@ pub fn execute_unrelate(entity_name: &str, parent_name: &str, db_path: &Path) ->
 mod tests {
     use super::*;
     use crate::models::entity::Entity;
-    use crate::storage::connection::get_memory_connection;
+    use tempfile::TempDir;
 
     fn setup_entity(conn: &Connection, name: &str) {
         let entity = Entity::new(name.to_string());
         EntitiesRepository::find_or_create(conn, &entity).unwrap();
     }
 
-    fn relate_in_memory(child: &str, parent: &str) -> (Connection, Result<(), ThoughtError>) {
-        let conn = get_memory_connection().unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, child);
-        setup_entity(&conn, parent);
-
-        let child_entity = EntitiesRepository::find_by_name(&conn, child).unwrap().unwrap();
-        let parent_entity = EntitiesRepository::find_by_name(&conn, parent).unwrap().unwrap();
-
-        if child_entity.id == parent_entity.id {
-            return (conn, Err(ThoughtError::SelfRelation(child.to_string())));
-        }
-
-        let would_cycle =
-            EntityRelationsRepository::would_create_cycle(&conn, child_entity.id.unwrap(), parent_entity.id.unwrap())
-                .unwrap();
-        if would_cycle {
-            return (
-                conn,
-                Err(ThoughtError::RelationCycle {
-                    child: child_entity.canonical_name,
-                    parent: parent_entity.canonical_name,
-                }),
-            );
-        }
-
-        let result =
-            EntityRelationsRepository::add_relation(&conn, child_entity.id.unwrap(), parent_entity.id.unwrap());
-        (conn, result)
-    }
-
-    #[test]
-    fn test_relate_creates_relation() {
-        let (conn, result) = relate_in_memory("AWS", "Amazon");
-        assert!(result.is_ok());
-
-        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
-        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
-        assert_eq!(children.len(), 1);
-        assert_eq!(children[0].canonical_name, "AWS");
-    }
-
-    #[test]
-    fn test_relate_self_relation_rejected() {
-        let (_conn, result) = relate_in_memory("Amazon", "Amazon");
-        assert!(matches!(result, Err(ThoughtError::SelfRelation(_))));
-    }
-
-    #[test]
-    fn test_relate_cycle_rejected() {
-        let conn = get_memory_connection().unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        setup_entity(&conn, "AWS");
-
-        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
-        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
-
-        EntityRelationsRepository::add_relation(&conn, aws.id.unwrap(), amazon.id.unwrap()).unwrap();
-
-        let would_cycle =
-            EntityRelationsRepository::would_create_cycle(&conn, amazon.id.unwrap(), aws.id.unwrap()).unwrap();
-        assert!(would_cycle);
-    }
-
-    #[test]
-    fn test_relate_idempotent() {
-        let (conn, first) = relate_in_memory("AWS", "Amazon");
-        assert!(first.is_ok());
-
-        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
-        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
-
-        let second = EntityRelationsRepository::add_relation(&conn, aws.id.unwrap(), amazon.id.unwrap());
-        assert!(second.is_ok());
-
-        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
-        assert_eq!(children.len(), 1);
-    }
-
-    #[test]
-    fn test_unrelate_removes_relation() {
-        let (conn, result) = relate_in_memory("AWS", "Amazon");
-        assert!(result.is_ok());
-
-        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
-        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
-
-        EntityRelationsRepository::remove_relation(&conn, aws.id.unwrap(), amazon.id.unwrap()).unwrap();
-
-        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
-        assert!(children.is_empty());
-    }
-
-    #[test]
-    fn test_unrelate_nonexistent_relation_is_noop() {
-        let conn = get_memory_connection().unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        setup_entity(&conn, "AWS");
-
-        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
-        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
-
-        let result = EntityRelationsRepository::remove_relation(&conn, aws.id.unwrap(), amazon.id.unwrap());
-        assert!(result.is_ok());
-    }
-
-    #[test]
-    fn test_execute_relate_end_to_end() {
-        use tempfile::TempDir;
-
+    /// Create a temp-file-backed database with the given entities already present,
+    /// so tests exercise `execute_relate`/`execute_unrelate` themselves (the real
+    /// command functions) rather than reimplementing their logic against an
+    /// in-memory connection.
+    fn temp_db_with_entities(names: &[&str]) -> (TempDir, std::path::PathBuf) {
         let temp_dir = TempDir::new().unwrap();
         let db_path = temp_dir.path().join("test.db");
 
         let conn = get_connection(&db_path).unwrap();
         run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        setup_entity(&conn, "AWS");
-        drop(conn);
+        for name in names {
+            setup_entity(&conn, name);
+        }
+
+        (temp_dir, db_path)
+    }
+
+    #[test]
+    fn test_execute_relate_creates_relation() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
 
         let result = execute_relate("AWS", "Amazon", &db_path);
         assert!(result.is_ok());
@@ -224,15 +124,7 @@ mod tests {
 
     #[test]
     fn test_execute_relate_missing_child_errors() {
-        use tempfile::TempDir;
-
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-
-        let conn = get_connection(&db_path).unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        drop(conn);
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon"]);
 
         let result = execute_relate("AWS", "Amazon", &db_path);
         assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "AWS"));
@@ -240,32 +132,36 @@ mod tests {
 
     #[test]
     fn test_execute_relate_missing_parent_errors() {
-        use tempfile::TempDir;
-
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-
-        let conn = get_connection(&db_path).unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "AWS");
-        drop(conn);
+        let (_temp_dir, db_path) = temp_db_with_entities(&["AWS"]);
 
         let result = execute_relate("AWS", "Amazon", &db_path);
         assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "Amazon"));
     }
 
     #[test]
-    fn test_execute_relate_cycle_rolls_back() {
-        use tempfile::TempDir;
+    fn test_execute_relate_self_relation_rejected() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon"]);
 
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
+        let result = execute_relate("Amazon", "Amazon", &db_path);
+        assert!(matches!(result, Err(ThoughtError::SelfRelation(_))));
+    }
+
+    #[test]
+    fn test_execute_relate_idempotent() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
+
+        assert!(execute_relate("AWS", "Amazon", &db_path).is_ok());
+        assert!(execute_relate("AWS", "Amazon", &db_path).is_ok());
 
         let conn = get_connection(&db_path).unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        setup_entity(&conn, "AWS");
-        drop(conn);
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert_eq!(children.len(), 1);
+    }
+
+    #[test]
+    fn test_execute_relate_cycle_rolls_back() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
 
         execute_relate("AWS", "Amazon", &db_path).unwrap();
 
@@ -280,17 +176,8 @@ mod tests {
     }
 
     #[test]
-    fn test_execute_unrelate_end_to_end() {
-        use tempfile::TempDir;
-
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-
-        let conn = get_connection(&db_path).unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        setup_entity(&conn, "AWS");
-        drop(conn);
+    fn test_execute_unrelate_removes_relation() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
 
         execute_relate("AWS", "Amazon", &db_path).unwrap();
         let result = execute_unrelate("AWS", "Amazon", &db_path);
@@ -303,16 +190,16 @@ mod tests {
     }
 
     #[test]
+    fn test_execute_unrelate_nonexistent_relation_is_noop() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
+
+        let result = execute_unrelate("AWS", "Amazon", &db_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
     fn test_execute_unrelate_requires_both_entities_to_exist() {
-        use tempfile::TempDir;
-
-        let temp_dir = TempDir::new().unwrap();
-        let db_path = temp_dir.path().join("test.db");
-
-        let conn = get_connection(&db_path).unwrap();
-        run_migrations(&conn).unwrap();
-        setup_entity(&conn, "Amazon");
-        drop(conn);
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon"]);
 
         let result = execute_unrelate("AWS", "Amazon", &db_path);
         assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "AWS"));

--- a/src/cli/entity_show.rs
+++ b/src/cli/entity_show.rs
@@ -4,6 +4,7 @@ use crate::services::color_mode::ColorMode;
 use crate::services::entity_styler::EntityStyler;
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_relations_repository::EntityRelationsRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 use std::path::Path;
@@ -39,6 +40,20 @@ pub fn execute(entity_name: &str, db_path: &Path, color_mode: ColorMode) -> Resu
     if let Some(description) = &entity.description {
         println!();
         println!("{}", styler.render_content(description));
+    }
+
+    let parents = EntityRelationsRepository::list_parents(&conn, entity.id.unwrap())?;
+    let children = EntityRelationsRepository::list_children(&conn, entity.id.unwrap())?;
+
+    if !parents.is_empty() {
+        let names: Vec<_> = parents.iter().map(|e| e.canonical_name.as_str()).collect();
+        println!();
+        println!("Parents: {}", names.join(", "));
+    }
+    if !children.is_empty() {
+        let names: Vec<_> = children.iter().map(|e| e.canonical_name.as_str()).collect();
+        println!();
+        println!("Children: {}", names.join(", "));
     }
 
     println!();
@@ -96,6 +111,47 @@ mod tests {
 
         let entity = EntitiesRepository::find_by_name(&conn, "rust").unwrap().unwrap();
         assert!(entity.description.is_none());
+    }
+
+    #[test]
+    fn test_show_with_parents_and_children_succeeds() {
+        use crate::storage::entity_relations_repository::EntityRelationsRepository;
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let conn = get_connection(&db_path).unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        setup_entity(&conn, "amazon", None);
+        setup_entity(&conn, "aws", None);
+        setup_entity(&conn, "big tech", None);
+
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+        let big_tech = EntitiesRepository::find_by_name(&conn, "big tech").unwrap().unwrap();
+        EntityRelationsRepository::add_relation(&conn, aws.id.unwrap(), amazon.id.unwrap()).unwrap();
+        EntityRelationsRepository::add_relation(&conn, amazon.id.unwrap(), big_tech.id.unwrap()).unwrap();
+        drop(conn);
+
+        let result = execute("amazon", &db_path, ColorMode::Never);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_show_without_relations_succeeds() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let conn = get_connection(&db_path).unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        setup_entity(&conn, "rust", None);
+        drop(conn);
+
+        let result = execute("rust", &db_path, ColorMode::Never);
+        assert!(result.is_ok());
     }
 
     #[test]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -5,6 +5,7 @@ pub mod delete;
 pub mod edit;
 pub mod entities;
 pub mod entity_edit;
+pub mod entity_relate;
 pub mod entity_rename;
 pub mod entity_show;
 pub mod thoughts;
@@ -101,5 +102,21 @@ pub enum EntityCommands {
     Show {
         /// Entity name (case-insensitive)
         entity_name: String,
+    },
+    /// Mark an entity as a child of another entity
+    Relate {
+        /// Entity to mark as a child (case-insensitive)
+        entity_name: String,
+        /// Parent entity name (case-insensitive)
+        #[arg(long)]
+        parent: String,
+    },
+    /// Remove a parent/child relation between two entities
+    Unrelate {
+        /// Child entity name (case-insensitive)
+        entity_name: String,
+        /// Parent entity name (case-insensitive)
+        #[arg(long)]
+        parent: String,
     },
 }

--- a/src/cli/tui.rs
+++ b/src/cli/tui.rs
@@ -9,18 +9,23 @@ use crate::errors::ThoughtError;
 use crate::models::SortOrder;
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_relations_repository::EntityRelationsRepository;
+use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 use crate::tui::App;
 
 /// Launch the interactive TUI thought viewer.
 pub fn execute(db_path: &Path, sort_order: SortOrder) -> Result<(), ThoughtError> {
     let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
     let thoughts = ThoughtsRepository::list_all(&conn)?;
     let entities = EntitiesRepository::list_all(&conn)?;
+    let relations = EntityRelationsRepository::list_all_edges(&conn)?;
 
     let mut terminal = ratatui::init();
 
     let result = App::new(thoughts, entities, sort_order)
+        .with_relations(relations)
         .with_db_path(db_path.to_path_buf())
         .run(&mut terminal);
 

--- a/src/errors/thought_error.rs
+++ b/src/errors/thought_error.rs
@@ -35,6 +35,14 @@ pub enum ThoughtError {
 
     #[error("TUI error: {0}")]
     TuiError(String),
+
+    #[error(
+        "Cannot make '{child}' a child of '{parent}': '{parent}' is already a descendant of '{child}' (would create a cycle)"
+    )]
+    RelationCycle { child: String, parent: String },
+
+    #[error("An entity cannot be its own parent: '{0}'")]
+    SelfRelation(String),
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -69,6 +69,12 @@ fn main() {
             EntityCommands::Show { entity_name } => {
                 wetware::cli::entity_show::execute(&entity_name, &db_path, cli.color)
             }
+            EntityCommands::Relate { entity_name, parent } => {
+                wetware::cli::entity_relate::execute_relate(&entity_name, &parent, &db_path)
+            }
+            EntityCommands::Unrelate { entity_name, parent } => {
+                wetware::cli::entity_relate::execute_unrelate(&entity_name, &parent, &db_path)
+            }
         },
     };
 

--- a/src/storage/entity_relations_repository.rs
+++ b/src/storage/entity_relations_repository.rs
@@ -1,0 +1,267 @@
+/// Repository for directed entity relations (parent/child) persistence
+use crate::errors::ThoughtError;
+use crate::models::entity::Entity;
+use rusqlite::Connection;
+
+/// Recursive CTE computing all entity ids reachable as descendants of `?1`
+/// (following child edges downward), including `?1` itself.
+const DESCENDANTS_CTE: &str = "
+    WITH RECURSIVE descendants(id) AS (
+        SELECT ?1
+        UNION
+        SELECT er.child_id FROM entity_relations er JOIN descendants d ON er.parent_id = d.id
+    )
+";
+
+/// Entity relations repository for database operations
+pub struct EntityRelationsRepository;
+
+impl EntityRelationsRepository {
+    /// Mark `child_id` as a child of `parent_id`. Idempotent - a no-op if the
+    /// relation already exists.
+    pub fn add_relation(conn: &Connection, child_id: i64, parent_id: i64) -> Result<(), ThoughtError> {
+        conn.execute(
+            "INSERT OR IGNORE INTO entity_relations (child_id, parent_id) VALUES (?1, ?2)",
+            (child_id, parent_id),
+        )?;
+        Ok(())
+    }
+
+    /// Remove the child/parent relation if present. Safe to call even if no such
+    /// relation exists (no-op).
+    pub fn remove_relation(conn: &Connection, child_id: i64, parent_id: i64) -> Result<(), ThoughtError> {
+        conn.execute(
+            "DELETE FROM entity_relations WHERE child_id = ?1 AND parent_id = ?2",
+            (child_id, parent_id),
+        )?;
+        Ok(())
+    }
+
+    /// True if `parent_id` is already reachable as a descendant of `child_id`,
+    /// meaning adding a `child_id` -> `parent_id` edge would make `child_id` its
+    /// own (transitive) ancestor.
+    pub fn would_create_cycle(conn: &Connection, child_id: i64, parent_id: i64) -> Result<bool, ThoughtError> {
+        let sql = format!("{DESCENDANTS_CTE} SELECT EXISTS(SELECT 1 FROM descendants WHERE id = ?2)");
+        let exists: bool = conn.query_row(&sql, (child_id, parent_id), |row| row.get(0))?;
+        Ok(exists)
+    }
+
+    /// Direct (non-transitive) parents of the given entity.
+    pub fn list_parents(conn: &Connection, entity_id: i64) -> Result<Vec<Entity>, ThoughtError> {
+        let mut stmt = conn.prepare(
+            "SELECT e.id, e.name, e.canonical_name, e.description
+             FROM entities e
+             INNER JOIN entity_relations er ON er.parent_id = e.id
+             WHERE er.child_id = ?1
+             ORDER BY e.canonical_name ASC",
+        )?;
+
+        let entities = stmt
+            .query_map([entity_id], Self::row_to_entity)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(entities)
+    }
+
+    /// Direct (non-transitive) children of the given entity.
+    pub fn list_children(conn: &Connection, entity_id: i64) -> Result<Vec<Entity>, ThoughtError> {
+        let mut stmt = conn.prepare(
+            "SELECT e.id, e.name, e.canonical_name, e.description
+             FROM entities e
+             INNER JOIN entity_relations er ON er.child_id = e.id
+             WHERE er.parent_id = ?1
+             ORDER BY e.canonical_name ASC",
+        )?;
+
+        let entities = stmt
+            .query_map([entity_id], Self::row_to_entity)?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(entities)
+    }
+
+    /// All relation edges as `(child_id, parent_id)` pairs.
+    pub fn list_all_edges(conn: &Connection) -> Result<Vec<(i64, i64)>, ThoughtError> {
+        let mut stmt = conn.prepare("SELECT child_id, parent_id FROM entity_relations")?;
+
+        let edges = stmt
+            .query_map([], |row| Ok((row.get(0)?, row.get(1)?)))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(edges)
+    }
+
+    fn row_to_entity(row: &rusqlite::Row) -> rusqlite::Result<Entity> {
+        Ok(Entity {
+            id: Some(row.get(0)?),
+            name: row.get(1)?,
+            canonical_name: row.get(2)?,
+            description: row.get(3)?,
+        })
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::connection::get_memory_connection;
+    use crate::storage::entities_repository::EntitiesRepository;
+    use crate::storage::migrations::run_migrations;
+
+    fn make_entity(conn: &Connection, name: &str) -> i64 {
+        let entity = Entity::new(name.to_string());
+        EntitiesRepository::find_or_create(conn, &entity).unwrap()
+    }
+
+    #[test]
+    fn test_add_relation_creates_parent_child_link() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+        let amazon = make_entity(&conn, "Amazon");
+
+        EntityRelationsRepository::add_relation(&conn, aws, amazon).unwrap();
+
+        let children = EntityRelationsRepository::list_children(&conn, amazon).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].canonical_name, "AWS");
+
+        let parents = EntityRelationsRepository::list_parents(&conn, aws).unwrap();
+        assert_eq!(parents.len(), 1);
+        assert_eq!(parents[0].canonical_name, "Amazon");
+    }
+
+    #[test]
+    fn test_add_relation_idempotent() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+        let amazon = make_entity(&conn, "Amazon");
+
+        EntityRelationsRepository::add_relation(&conn, aws, amazon).unwrap();
+        EntityRelationsRepository::add_relation(&conn, aws, amazon).unwrap();
+
+        let count: i64 = conn
+            .query_row("SELECT COUNT(*) FROM entity_relations", [], |row| row.get(0))
+            .unwrap();
+        assert_eq!(count, 1);
+    }
+
+    #[test]
+    fn test_remove_relation_removes_existing() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+        let amazon = make_entity(&conn, "Amazon");
+
+        EntityRelationsRepository::add_relation(&conn, aws, amazon).unwrap();
+        EntityRelationsRepository::remove_relation(&conn, aws, amazon).unwrap();
+
+        let children = EntityRelationsRepository::list_children(&conn, amazon).unwrap();
+        assert!(children.is_empty());
+    }
+
+    #[test]
+    fn test_remove_relation_nonexistent_is_noop() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+        let amazon = make_entity(&conn, "Amazon");
+
+        let result = EntityRelationsRepository::remove_relation(&conn, aws, amazon);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_would_create_cycle_direct() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let a = make_entity(&conn, "A");
+        let b = make_entity(&conn, "B");
+
+        // B is a child of A
+        EntityRelationsRepository::add_relation(&conn, b, a).unwrap();
+
+        // Making A a child of B would create a cycle
+        assert!(EntityRelationsRepository::would_create_cycle(&conn, a, b).unwrap());
+    }
+
+    #[test]
+    fn test_would_create_cycle_indirect_chain() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let a = make_entity(&conn, "A");
+        let b = make_entity(&conn, "B");
+        let c = make_entity(&conn, "C");
+
+        // C child-of B child-of A
+        EntityRelationsRepository::add_relation(&conn, b, a).unwrap();
+        EntityRelationsRepository::add_relation(&conn, c, b).unwrap();
+
+        // Making A a child of C would create a cycle (A -> C -> B -> A)
+        assert!(EntityRelationsRepository::would_create_cycle(&conn, a, c).unwrap());
+    }
+
+    #[test]
+    fn test_would_create_cycle_unrelated_entities() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let a = make_entity(&conn, "A");
+        let b = make_entity(&conn, "B");
+
+        assert!(!EntityRelationsRepository::would_create_cycle(&conn, a, b).unwrap());
+    }
+
+    #[test]
+    fn test_would_create_cycle_multi_parent_dag() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let amazon = make_entity(&conn, "Amazon");
+        let satellite_domain = make_entity(&conn, "Satellite Connectivity Domain");
+        let amazon_leo = make_entity(&conn, "Amazon Leo");
+        let other = make_entity(&conn, "Other");
+
+        // Amazon Leo is a child of both Amazon and satellite connectivity domain
+        EntityRelationsRepository::add_relation(&conn, amazon_leo, amazon).unwrap();
+        EntityRelationsRepository::add_relation(&conn, amazon_leo, satellite_domain).unwrap();
+
+        // Making Amazon a child of Amazon Leo would create a cycle
+        assert!(EntityRelationsRepository::would_create_cycle(&conn, amazon, amazon_leo).unwrap());
+
+        // Making an unrelated third entity a further child of Amazon Leo is fine
+        assert!(!EntityRelationsRepository::would_create_cycle(&conn, other, amazon_leo).unwrap());
+    }
+
+    #[test]
+    fn test_list_all_edges() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+        let amazon = make_entity(&conn, "Amazon");
+
+        EntityRelationsRepository::add_relation(&conn, aws, amazon).unwrap();
+
+        let edges = EntityRelationsRepository::list_all_edges(&conn).unwrap();
+        assert_eq!(edges, vec![(aws, amazon)]);
+    }
+
+    #[test]
+    fn test_list_parents_and_children_empty_when_no_relations() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let aws = make_entity(&conn, "AWS");
+
+        assert!(EntityRelationsRepository::list_parents(&conn, aws).unwrap().is_empty());
+        assert!(EntityRelationsRepository::list_children(&conn, aws).unwrap().is_empty());
+    }
+}

--- a/src/storage/migrations/entity_relations_migration.rs
+++ b/src/storage/migrations/entity_relations_migration.rs
@@ -1,0 +1,75 @@
+/// Database migration for directed entity relations (parent/child)
+/// Creates table: entity_relations
+use rusqlite::{Connection, Result};
+
+pub fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS entity_relations (
+            child_id INTEGER NOT NULL,
+            parent_id INTEGER NOT NULL,
+            PRIMARY KEY (child_id, parent_id),
+            FOREIGN KEY (child_id) REFERENCES entities(id) ON DELETE CASCADE,
+            FOREIGN KEY (parent_id) REFERENCES entities(id) ON DELETE CASCADE,
+            CHECK (child_id != parent_id)
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_entity_relations_parent ON entity_relations(parent_id)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_entity_relations_child ON entity_relations(child_id)",
+        [],
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_creates_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(tables.contains(&"entity_relations".to_string()));
+    }
+
+    #[test]
+    fn test_migration_creates_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let indexes: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(indexes.contains(&"idx_entity_relations_parent".to_string()));
+        assert!(indexes.contains(&"idx_entity_relations_child".to_string()));
+    }
+
+    #[test]
+    fn test_migration_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        migrate(&conn).unwrap();
+        migrate(&conn).unwrap();
+    }
+}

--- a/src/storage/migrations/mod.rs
+++ b/src/storage/migrations/mod.rs
@@ -1,5 +1,6 @@
 /// Database migrations module
 pub mod add_entity_descriptions_migration;
+pub mod entity_relations_migration;
 pub mod networked_notes_migration;
 
 use crate::errors::ThoughtError;
@@ -12,6 +13,9 @@ pub fn run_migrations(conn: &Connection) -> Result<(), ThoughtError> {
 
     // Run migration 002: entity descriptions
     add_entity_descriptions_migration::migrate_add_entity_descriptions(conn)?;
+
+    // Run migration 003: entity relations
+    entity_relations_migration::migrate(conn)?;
 
     Ok(())
 }

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,11 +1,13 @@
 pub mod connection;
 pub mod data_dir;
 pub mod entities_repository;
+pub mod entity_relations_repository;
 pub mod migrations;
 pub mod thoughts_repository;
 
 pub use connection::{get_connection, get_memory_connection};
 pub use data_dir::{default_db_path_in, ensure_data_dir, resolve_data_dir};
 pub use entities_repository::EntitiesRepository;
+pub use entity_relations_repository::EntityRelationsRepository;
 pub use migrations::run_migrations;
 pub use thoughts_repository::ThoughtsRepository;

--- a/src/storage/thoughts_repository.rs
+++ b/src/storage/thoughts_repository.rs
@@ -101,16 +101,21 @@ impl ThoughtsRepository {
         Ok(())
     }
 
-    /// List thoughts filtered by entity name (case-insensitive)
+    /// List thoughts filtered by entity name (case-insensitive), including thoughts
+    /// linked to any entity transitively reachable via child relations (descendants).
     pub fn list_by_entity(conn: &Connection, entity_name: &str) -> Result<Vec<Thought>, ThoughtError> {
         let lowercase_name = entity_name.to_lowercase();
 
         let mut stmt = conn.prepare(
-            "SELECT DISTINCT t.id, t.content, t.created_at
+            "WITH RECURSIVE reachable(id) AS (
+                 SELECT id FROM entities WHERE name = ?1
+                 UNION
+                 SELECT er.child_id FROM entity_relations er JOIN reachable r ON er.parent_id = r.id
+             )
+             SELECT DISTINCT t.id, t.content, t.created_at
              FROM thoughts t
              INNER JOIN thought_entities te ON t.id = te.thought_id
-             INNER JOIN entities e ON te.entity_id = e.id
-             WHERE e.name = ?1
+             INNER JOIN reachable r ON te.entity_id = r.id
              ORDER BY t.created_at ASC",
         )?;
 
@@ -134,7 +139,9 @@ impl ThoughtsRepository {
         Ok(thoughts)
     }
 
-    /// List the most recent thoughts linked to an entity (case-insensitive), newest first
+    /// List the most recent thoughts linked to an entity (case-insensitive), newest first,
+    /// including thoughts linked to any entity transitively reachable via child relations
+    /// (descendants).
     pub fn list_latest_by_entity(
         conn: &Connection,
         entity_name: &str,
@@ -143,11 +150,15 @@ impl ThoughtsRepository {
         let lowercase_name = entity_name.to_lowercase();
 
         let mut stmt = conn.prepare(
-            "SELECT DISTINCT t.id, t.content, t.created_at
+            "WITH RECURSIVE reachable(id) AS (
+                 SELECT id FROM entities WHERE name = ?1
+                 UNION
+                 SELECT er.child_id FROM entity_relations er JOIN reachable r ON er.parent_id = r.id
+             )
+             SELECT DISTINCT t.id, t.content, t.created_at
              FROM thoughts t
              INNER JOIN thought_entities te ON t.id = te.thought_id
-             INNER JOIN entities e ON te.entity_id = e.id
-             WHERE e.name = ?1
+             INNER JOIN reachable r ON te.entity_id = r.id
              ORDER BY t.created_at DESC
              LIMIT ?2",
         )?;
@@ -421,5 +432,125 @@ mod tests {
         let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "RUST", 5).unwrap();
         assert_eq!(thoughts.len(), 1);
         assert_eq!(thoughts[0].content, "About Rust");
+    }
+
+    fn relate(conn: &Connection, child_name: &str, parent_name: &str) {
+        use crate::storage::entities_repository::EntitiesRepository;
+        use crate::storage::entity_relations_repository::EntityRelationsRepository;
+
+        let child_id = EntitiesRepository::find_by_name(conn, child_name)
+            .unwrap()
+            .unwrap()
+            .id
+            .unwrap();
+        let parent_id = EntitiesRepository::find_by_name(conn, parent_name)
+            .unwrap()
+            .unwrap()
+            .id
+            .unwrap();
+        EntityRelationsRepository::add_relation(conn, child_id, parent_id).unwrap();
+    }
+
+    #[test]
+    fn test_list_by_entity_no_relations_behaves_as_before() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "About Rust", "Rust", day(0));
+        save_linked_thought(&conn, "About Go", "Go", day(0));
+
+        let thoughts = ThoughtsRepository::list_by_entity(&conn, "rust").unwrap();
+        assert_eq!(thoughts.len(), 1);
+        assert_eq!(thoughts[0].content, "About Rust");
+    }
+
+    #[test]
+    fn test_list_by_entity_includes_descendant_thoughts() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "About Amazon", "Amazon", day(-1));
+        save_linked_thought(&conn, "About AWS", "AWS", day(0));
+        relate(&conn, "AWS", "Amazon");
+
+        let thoughts = ThoughtsRepository::list_by_entity(&conn, "amazon").unwrap();
+        let contents: Vec<_> = thoughts.iter().map(|t| t.content.as_str()).collect();
+        assert_eq!(contents, vec!["About Amazon", "About AWS"]);
+    }
+
+    #[test]
+    fn test_list_by_entity_thought_on_root_still_included() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        use crate::models::entity::Entity;
+        use crate::storage::entities_repository::EntitiesRepository;
+
+        save_linked_thought(&conn, "About Amazon", "Amazon", day(0));
+        EntitiesRepository::find_or_create(&conn, &Entity::new("AWS".to_string())).unwrap();
+        relate(&conn, "AWS", "Amazon");
+
+        let thoughts = ThoughtsRepository::list_by_entity(&conn, "amazon").unwrap();
+        assert_eq!(thoughts.len(), 1);
+        assert_eq!(thoughts[0].content, "About Amazon");
+    }
+
+    #[test]
+    fn test_list_by_entity_diamond_shape_no_duplicates() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        // Diamond: D is child of both B and C, both of which are children of A.
+        save_linked_thought(&conn, "About A", "A", day(-3));
+        save_linked_thought(&conn, "About B", "B", day(-2));
+        save_linked_thought(&conn, "About C", "C", day(-1));
+        save_linked_thought(&conn, "About D", "D", day(0));
+        relate(&conn, "B", "A");
+        relate(&conn, "C", "A");
+        relate(&conn, "D", "B");
+        relate(&conn, "D", "C");
+
+        let thoughts = ThoughtsRepository::list_by_entity(&conn, "a").unwrap();
+        assert_eq!(thoughts.len(), 4);
+        let d_count = thoughts.iter().filter(|t| t.content == "About D").count();
+        assert_eq!(d_count, 1);
+    }
+
+    #[test]
+    fn test_list_by_entity_unknown_entity_returns_empty() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let thoughts = ThoughtsRepository::list_by_entity(&conn, "nonexistent").unwrap();
+        assert!(thoughts.is_empty());
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_includes_descendant_thoughts() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "About Amazon", "Amazon", day(-1));
+        save_linked_thought(&conn, "About AWS", "AWS", day(0));
+        relate(&conn, "AWS", "Amazon");
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "amazon", 5).unwrap();
+        assert_eq!(thoughts.len(), 2);
+        assert_eq!(thoughts[0].content, "About AWS");
+        assert_eq!(thoughts[1].content, "About Amazon");
+    }
+
+    #[test]
+    fn test_list_latest_by_entity_limit_applies_across_descendants() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        save_linked_thought(&conn, "About Amazon", "Amazon", day(-1));
+        save_linked_thought(&conn, "About AWS", "AWS", day(0));
+        relate(&conn, "AWS", "Amazon");
+
+        let thoughts = ThoughtsRepository::list_latest_by_entity(&conn, "amazon", 1).unwrap();
+        assert_eq!(thoughts.len(), 1);
+        assert_eq!(thoughts[0].content, "About AWS");
     }
 }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -30,6 +30,7 @@ fn handle_normal_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Esc => {
             if app.active_filter.is_some() {
                 app.active_filter = None;
+                app.active_filter_reachable.clear();
                 app.recompute_displayed_thoughts();
             } else {
                 app.should_quit = true;
@@ -140,6 +141,7 @@ fn handle_entity_picker_mode(app: &mut App, key: KeyEvent) {
         KeyCode::Enter => {
             if let Some(&entity_idx) = matches.get(*selected) {
                 let entity_name = app.entities[entity_idx].canonical_name.clone();
+                app.active_filter_reachable = app.reachable_names(entity_idx);
                 app.active_filter = Some(entity_name);
                 app.mode = Mode::Normal;
                 app.recompute_displayed_thoughts();

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -7,6 +7,7 @@ pub mod input;
 pub mod state;
 pub mod ui;
 
+use std::collections::{HashMap, HashSet};
 use std::path::PathBuf;
 
 use ratatui::crossterm::event::{self, Event, KeyEventKind};
@@ -38,12 +39,17 @@ pub struct App {
     pub mode: Mode,
     /// Current sort direction
     pub sort_order: SortOrder,
-    /// Entity name currently filtering by (None = show all)
+    /// Entity name currently filtering by (None = show all), kept for display purposes
     pub active_filter: Option<String>,
+    /// Lowercase names of the filter entity and all its transitive descendants (via
+    /// child relations); thoughts referencing any of these names pass the filter
+    pub active_filter_reachable: HashSet<String>,
     /// Exit flag
     pub should_quit: bool,
     /// Path to the database for mutation operations
     pub db_path: Option<PathBuf>,
+    /// Parent entity id -> child entity ids, built from loaded relation edges
+    entity_children: HashMap<i64, Vec<i64>>,
 }
 
 impl App {
@@ -57,8 +63,10 @@ impl App {
             mode: Mode::Normal,
             sort_order,
             active_filter: None,
+            active_filter_reachable: HashSet::new(),
             should_quit: false,
             db_path: None,
+            entity_children: HashMap::new(),
         };
         app.recompute_displayed_thoughts();
         if !app.displayed_thoughts.is_empty() {
@@ -71,6 +79,39 @@ impl App {
     pub fn with_db_path(mut self, db_path: PathBuf) -> Self {
         self.db_path = Some(db_path);
         self
+    }
+
+    /// Load the entity relation graph (child_id, parent_id edges) so entity-picker
+    /// filtering can include transitive descendants.
+    pub fn with_relations(mut self, relations: Vec<(i64, i64)>) -> Self {
+        let mut entity_children: HashMap<i64, Vec<i64>> = HashMap::new();
+        for (child_id, parent_id) in relations {
+            entity_children.entry(parent_id).or_default().push(child_id);
+        }
+        self.entity_children = entity_children;
+        self
+    }
+
+    /// Lowercase names of `entities[root_idx]` and every entity transitively
+    /// reachable from it via child relations (descendants).
+    pub fn reachable_names(&self, root_idx: usize) -> HashSet<String> {
+        let mut visited_ids = HashSet::new();
+        let mut stack = vec![self.entities[root_idx].id.unwrap()];
+
+        while let Some(id) = stack.pop() {
+            if !visited_ids.insert(id) {
+                continue;
+            }
+            if let Some(children) = self.entity_children.get(&id) {
+                stack.extend(children.iter().copied());
+            }
+        }
+
+        self.entities
+            .iter()
+            .filter(|e| e.id.is_some_and(|id| visited_ids.contains(&id)))
+            .map(|e| e.name.clone())
+            .collect()
     }
 
     /// Delete the thought currently pending confirmation.
@@ -104,14 +145,15 @@ impl App {
 
     /// Recompute the displayed thoughts based on current filter and sort order.
     pub fn recompute_displayed_thoughts(&mut self) {
-        let mut indices: Vec<usize> = if let Some(ref filter_entity) = self.active_filter {
-            let filter_lower = filter_entity.to_lowercase();
+        let mut indices: Vec<usize> = if self.active_filter.is_some() {
             self.thoughts
                 .iter()
                 .enumerate()
                 .filter(|(_, thought)| {
                     let entities = entity_parser::extract_entities(&thought.content);
-                    entities.iter().any(|e| e.to_lowercase() == filter_lower)
+                    entities
+                        .iter()
+                        .any(|e| self.active_filter_reachable.contains(&e.to_lowercase()))
                 })
                 .map(|(i, _)| i)
                 .collect()
@@ -281,6 +323,7 @@ mod tests {
         ];
         let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
+        app.active_filter_reachable = ["sarah".to_string()].into_iter().collect();
         app.recompute_displayed_thoughts();
         assert_eq!(app.displayed_thoughts.len(), 2);
     }
@@ -293,10 +336,12 @@ mod tests {
         ];
         let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
+        app.active_filter_reachable = ["sarah".to_string()].into_iter().collect();
         app.recompute_displayed_thoughts();
         assert_eq!(app.displayed_thoughts.len(), 1);
 
         app.active_filter = None;
+        app.active_filter_reachable.clear();
         app.recompute_displayed_thoughts();
         assert_eq!(app.displayed_thoughts.len(), 2);
     }
@@ -394,6 +439,115 @@ mod tests {
         let conn = get_connection(&db_path).unwrap();
         let remaining = ThoughtsRepository::list_all(&conn).unwrap();
         assert!(remaining.is_empty());
+    }
+
+    #[test]
+    fn test_reachable_names_no_relations_returns_only_self() {
+        let entities = vec![make_entity("Amazon", None)];
+        let app = App::new(vec![], entities, SortOrder::Ascending);
+
+        let names = app.reachable_names(0);
+        assert_eq!(names, ["amazon".to_string()].into_iter().collect());
+    }
+
+    #[test]
+    fn test_reachable_names_multi_level_chain() {
+        let entities = vec![
+            Entity {
+                id: Some(1),
+                name: "amazon".to_string(),
+                canonical_name: "Amazon".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(2),
+                name: "aws".to_string(),
+                canonical_name: "AWS".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(3),
+                name: "ec2".to_string(),
+                canonical_name: "EC2".to_string(),
+                description: None,
+            },
+        ];
+
+        // AWS child-of Amazon, EC2 child-of AWS
+        let app = App::new(vec![], entities, SortOrder::Ascending).with_relations(vec![(2, 1), (3, 2)]);
+
+        let names = app.reachable_names(0);
+        assert_eq!(
+            names,
+            ["amazon".to_string(), "aws".to_string(), "ec2".to_string()]
+                .into_iter()
+                .collect()
+        );
+    }
+
+    #[test]
+    fn test_reachable_names_diamond_shape() {
+        let entities = vec![
+            Entity {
+                id: Some(1),
+                name: "a".to_string(),
+                canonical_name: "A".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(2),
+                name: "b".to_string(),
+                canonical_name: "B".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(3),
+                name: "c".to_string(),
+                canonical_name: "C".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(4),
+                name: "d".to_string(),
+                canonical_name: "D".to_string(),
+                description: None,
+            },
+        ];
+        // B, C child-of A; D child-of both B and C
+        let app = App::new(vec![], entities, SortOrder::Ascending).with_relations(vec![(2, 1), (3, 1), (4, 2), (4, 3)]);
+
+        let names = app.reachable_names(0);
+        assert_eq!(names, ["a", "b", "c", "d"].into_iter().map(String::from).collect());
+    }
+
+    #[test]
+    fn test_recompute_displayed_thoughts_includes_descendant_tagged_thoughts() {
+        let thoughts = vec![
+            make_thought("About [Amazon]", 1),
+            make_thought("About [AWS]", 0),
+            make_thought("Unrelated", 2),
+        ];
+        let entities = vec![
+            Entity {
+                id: Some(1),
+                name: "amazon".to_string(),
+                canonical_name: "Amazon".to_string(),
+                description: None,
+            },
+            Entity {
+                id: Some(2),
+                name: "aws".to_string(),
+                canonical_name: "AWS".to_string(),
+                description: None,
+            },
+        ];
+        let mut app = App::new(thoughts, entities, SortOrder::Ascending).with_relations(vec![(2, 1)]);
+
+        app.active_filter = Some("Amazon".to_string());
+        app.active_filter_reachable = app.reachable_names(0);
+        app.recompute_displayed_thoughts();
+
+        assert_eq!(app.displayed_thoughts.len(), 2);
     }
 
     #[test]

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -575,6 +575,7 @@ mod tests {
         let thoughts = vec![make_thought("[Sarah] hello", 0)];
         let mut app = App::new(thoughts, vec![], SortOrder::Ascending);
         app.active_filter = Some("Sarah".to_string());
+        app.active_filter_reachable = ["sarah".to_string()].into_iter().collect();
         app.recompute_displayed_thoughts();
         let output = render_to_string(&app, 80, 10);
         assert!(output.contains("filtered: Sarah"));

--- a/tests/contract/mod.rs
+++ b/tests/contract/mod.rs
@@ -3,6 +3,7 @@ mod test_add_command;
 mod test_edit_command;
 mod test_entities_command;
 mod test_entity_edit_command;
+mod test_entity_relate_command;
 mod test_entity_rename_command;
 mod test_entity_show_command;
 mod test_thoughts_command;

--- a/tests/contract/test_entity_relate_command.rs
+++ b/tests/contract/test_entity_relate_command.rs
@@ -1,0 +1,125 @@
+/// Contract tests for `wet entity relate` / `wet entity unrelate` commands
+use crate::test_helpers::{run_wet_command, setup_temp_db};
+
+#[test]
+fn test_entity_relate_happy_path_expands_thoughts_filter() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Ordering from [Amazon]"], Some(&temp_db));
+    run_wet_command(&["add", "Setting up [AWS]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "relate", "aws", "--parent", "amazon"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("'aws' is now a child of 'amazon'"),
+        "Should show success message. Got: {}",
+        result.stdout
+    );
+
+    let thoughts_result = run_wet_command(&["thoughts", "--on", "amazon"], Some(&temp_db));
+    assert!(
+        thoughts_result.stdout.contains("Ordering from") && thoughts_result.stdout.contains("Setting up"),
+        "Filtering by 'amazon' should include the AWS-tagged thought too. Got: {}",
+        thoughts_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_relate_missing_entity_errors() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Ordering from [Amazon]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "relate", "aws", "--parent", "amazon"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("Entity 'aws' not found") || result.stdout.contains("Entity 'aws' not found"),
+        "Should show entity not found error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_relate_self_relation_rejected() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "About [Amazon]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "relate", "amazon", "--parent", "amazon"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("cannot be its own parent") || result.stdout.contains("cannot be its own parent"),
+        "Should show self-relation error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_relate_cycle_rejected() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "About [Amazon] and [AWS]"], Some(&temp_db));
+    run_wet_command(&["entity", "relate", "aws", "--parent", "amazon"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "relate", "amazon", "--parent", "aws"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("cycle") || result.stdout.contains("cycle"),
+        "Should show cycle error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_unrelate_removes_relation() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Ordering from [Amazon]"], Some(&temp_db));
+    run_wet_command(&["add", "Setting up [AWS]"], Some(&temp_db));
+    run_wet_command(&["entity", "relate", "aws", "--parent", "amazon"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "unrelate", "aws", "--parent", "amazon"], Some(&temp_db));
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("Removed 'aws' as a child of 'amazon'"),
+        "Should show success message. Got: {}",
+        result.stdout
+    );
+
+    let thoughts_result = run_wet_command(&["thoughts", "--on", "amazon"], Some(&temp_db));
+    assert!(
+        thoughts_result.stdout.contains("Ordering from") && !thoughts_result.stdout.contains("Setting up"),
+        "Filtering by 'amazon' should no longer include the AWS-tagged thought. Got: {}",
+        thoughts_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_show_lists_parents_and_children() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "About [Amazon]"], Some(&temp_db));
+    run_wet_command(&["add", "About [AWS]"], Some(&temp_db));
+    run_wet_command(&["entity", "relate", "aws", "--parent", "amazon"], Some(&temp_db));
+
+    let amazon_result = run_wet_command(&["entity", "show", "amazon"], Some(&temp_db));
+    assert!(
+        amazon_result.stdout.contains("Children: AWS"),
+        "Should list AWS as a child of Amazon. Got: {}",
+        amazon_result.stdout
+    );
+
+    let aws_result = run_wet_command(&["entity", "show", "aws"], Some(&temp_db));
+    assert!(
+        aws_result.stdout.contains("Parents: Amazon"),
+        "Should list Amazon as a parent of AWS. Got: {}",
+        aws_result.stdout
+    );
+}


### PR DESCRIPTION
## Summary
- Add `wet entity relate <name> --parent <parent>` / `wet entity unrelate <name> --parent <parent>` to mark directed child/parent relations between entities (DAG, multiple parents allowed; self-relations and cycles are rejected).
- Thought filtering everywhere in the app (`wet thoughts --on`, `wet entity show`, and the TUI entity picker) now includes thoughts for every entity transitively reachable from the filtered entity via child relations, via a recursive CTE.
- `wet entity show` now displays direct `Parents:`/`Children:` lines when present.
- New spec: `specs/012-entity-relations.md`.

## Test plan
- [x] `cargo nextest run` — 419 tests pass (unit, integration, and new contract tests for `relate`/`unrelate`)
- [x] `cargo clippy` clean (no new warnings)
- [x] `cargo fmt --check` clean
- [x] Manual smoke test: add/relate/filter/cycle-rejection/unrelate end-to-end via the built binary

🤖 Generated with [Claude Code](https://claude.com/claude-code)