### PR TITLE
feat: add known aliases for entities

### DIFF
--- a/docs/architecture/decisions/0013-entity-aliases.md
+++ b/docs/architecture/decisions/0013-entity-aliases.md
@@ -1,0 +1,120 @@
+---
+status: Accepted
+date: "2026-07-21"
+---
+
+# Entity Aliases
+
+## Context
+
+Entities have exactly one canonical name today, but people don't refer to the same real-world thing
+consistently — a nickname, an abbreviation, or a former name is often what actually gets typed. Without a
+persisted association, each of those alternate names either has to be the entity's literal, single stored
+name, or ends up creating a separate, disconnected entity that never shows up when filtering or browsing
+by the "real" name.
+
+This is a distinct problem from the existing `[alias](target)` bracket syntax handled by
+[`0004-entity-reference-aliases.md`](0004-entity-reference-aliases.md). That syntax is free-form,
+per-occurrence *display* text — it lets a single sentence read naturally ("started \[ML\](machine-learning)
+course") without changing what gets stored or looked up. ADR 0004 explicitly rejected building a persisted
+alias registry, but only in that narrower, presentational context, where aliases are one-off and never
+need to be reused across notes. This ADR is not reopening or contradicting that rejection — it addresses a
+different requirement 0004 never claimed to solve: is `nickname` actually the same entity as
+`entity-x`, durably and queryably, everywhere a name is looked up?
+
+## Decision
+
+Add a persisted alias registry: a new `entity_aliases` table associating zero or more alias strings with
+each entity, managed via `wet entity alias <name> --alias <x>` / `wet entity unalias <name> --alias <x>`
+(mirroring the `entity relate`/`entity unrelate` CLI shape). An alias is unique per entity
+(`PRIMARY KEY (entity_id, alias)`), not globally — the same alias string can be registered for two
+different entities, since real-world naming collisions across unrelated entities are common and
+shouldn't be blocked outright.
+
+Resolution is centralized in one function, `EntitiesRepository::resolve`, used everywhere an entity was
+previously looked up by exact name: `wet thoughts --on`, `wet entity show`/`edit`/`rename`/`relate`/
+`unrelate`, and `[bracket]` mentions extracted from thought/description text. It checks the canonical
+name first (exact, case-insensitive) — a canonical-name match always wins outright, even if some other
+entity also has that string registered as an alias, so an alias can never shadow a real entity name. Only
+when there's no canonical match are aliases consulted: zero matches means unresolved, one match resolves
+unambiguously, and more than one match (the same alias registered to different entities) is a first-class
+error (`ThoughtError::AmbiguousAlias`) rather than a silently arbitrary pick — silently choosing one of
+several candidates would be a worse failure mode than refusing to guess, since it could link data to the
+wrong entity with no visible signal.
+
+For `[bracket]` mentions specifically (`wet add`/`wet edit`/`entity edit`'s description references), an
+ambiguous alias match prints a warning to stderr naming the candidates and skips linking that one mention,
+without failing the whole command and without falling back to creating a new entity literally named after
+the ambiguous string. Entity extraction from thought/description text has never been able to fail the
+overall save before, and it shouldn't start here — a single ambiguous mention buried in otherwise-fine
+content failing the entire save would be disproportionate. Falling back to a literal new entity was
+rejected too: it would compound the ambiguity with a third, spurious entity and give the user no visible
+signal that anything needed fixing. Skip-with-warning has precedent in `edit --editor`'s abnormal-exit
+handling, which already treats a soft failure as warn-and-continue rather than a hard error.
+
+`wet entity rename` gains one additional guard: renaming an entity to a name that's already registered as
+an alias of a *different* entity is rejected (`ThoughtError::RenameCollidesWithAlias`), because
+`resolve()`'s canonical-wins-first rule means the rename would otherwise permanently and silently shadow
+that other entity's alias. Renaming to a name that is already the *same* entity's own alias is fine (no
+collision). No guard is added for the old name becoming free after a rename — that already happens
+unguarded for canonical names today, and aliases behave the same way for consistency: reuse of a freed-up
+name later, by anyone, is ordinary, not a collision to prevent.
+
+`wet entity show` gains an `Aliases: a, b, c` line, placed after the description and before
+`Parents:`/`Children:` (identity facts before relational context), omitted when the entity has none.
+
+## Consequences
+
+- `ThoughtsRepository::list_by_entity`/`list_latest_by_entity` no longer seed their reachability CTE with
+  `WHERE name = ?1` directly — they resolve the entity in Rust first (via `EntitiesRepository::resolve`)
+  and seed the CTE with the resolved id, since SQL can't express the ambiguity-vs-not-found distinction
+  inline. The not-found contract (empty results, not an error) is preserved exactly; only the new
+  ambiguous-alias case adds a new error path.
+- `add`/`edit`/`entity edit`'s entity-extraction loops gain their first-ever failure-adjacent behavior
+  (the ambiguous-mention warning) via a new shared helper, `entity_resolution::resolve_or_create_entity`,
+  rather than each duplicating resolve-then-branch logic independently.
+- `entity_edit.rs`, `entity_rename.rs`, and other CLI commands that resolve an entity by a possibly-aliased
+  name must use the *resolved* canonical name for any subsequent repository call that does its own
+  canonical-only lookup (e.g. `EntitiesRepository::update_description`) — passing the raw, alias-typed
+  argument through unchanged would otherwise fail with `EntityNotFound`.
+- The TUI's entity picker remains alias-*unaware* for this change — it fuzzy-matches and selects from an
+  in-memory `Vec<Entity>` loaded once at startup, by index, so the ambiguity problem this ADR addresses
+  doesn't arise there today. Making aliases searchable in the picker is a deliberate, documented follow-up,
+  not a gap.
+
+## Alternatives considered
+
+- **Global alias uniqueness** (one alias string, one entity, forever) — rejected: it over-constrains
+  real-world naming collisions between unrelated entities (two different people nicknamed "Boss", for
+  instance) that per-entity uniqueness handles naturally by surfacing ambiguity instead of blocking
+  registration.
+- **Picking the first alias match arbitrarily on ambiguity** — rejected: a silently wrong resolution
+  (linking to the wrong one of several candidates) is worse than an explicit, actionable error.
+- **Failing `add`/`edit` outright on an ambiguous mention** — rejected: entity extraction has always been
+  a best-effort side effect of saving, never a gate; blocking an entire save over one ambiguous bracket
+  reference is disproportionate to the problem.
+- **A nullable `entities.alias_of` self-referential column instead of a join table** — rejected for the
+  same reason [`0012-entity-relations.md`](0012-entity-relations.md) rejected a single `parent_id` column
+  for relations: an entity may reasonably want more than one alias, and a join table generalizes that
+  cleanly without a schema change later.
+
+## Related code
+
+- [`src/storage/migrations/entity_aliases_migration.rs`](../../../src/storage/migrations/entity_aliases_migration.rs)
+- [`src/storage/entity_aliases_repository.rs`](../../../src/storage/entity_aliases_repository.rs)
+- [`src/storage/entities_repository.rs`](../../../src/storage/entities_repository.rs) (`resolve`)
+- [`src/storage/thoughts_repository.rs`](../../../src/storage/thoughts_repository.rs)
+- [`src/services/entity_resolution.rs`](../../../src/services/entity_resolution.rs)
+- [`src/cli/entity_alias.rs`](../../../src/cli/entity_alias.rs)
+- [`src/cli/entity_rename.rs`](../../../src/cli/entity_rename.rs)
+- [`src/errors/thought_error.rs`](../../../src/errors/thought_error.rs) (`AmbiguousAlias`,
+  `RenameCollidesWithAlias`)
+
+## Related docs
+
+- [`../../systems/storage.md`](../../systems/storage.md)
+- [`../../systems/services.md`](../../systems/services.md)
+- [`../../systems/cli.md`](../../systems/cli.md)
+- [`../../flows/entity-alias-resolution.md`](../../flows/entity-alias-resolution.md)
+- [`0004-entity-reference-aliases.md`](0004-entity-reference-aliases.md)
+- [`0012-entity-relations.md`](0012-entity-relations.md)

--- a/docs/flows/entity-alias-resolution.md
+++ b/docs/flows/entity-alias-resolution.md
@@ -1,0 +1,117 @@
+# Entity Alias Resolution
+
+## Purpose
+
+Let a name that isn't an entity's canonical name still resolve to that entity everywhere a name is
+looked up — filtering, `entity show`/`edit`/`rename`/`relate`/`unrelate`, and `[bracket]` mentions
+extracted from thought/description text — via a persisted, per-entity alias registry.
+
+## Trigger
+
+Any lookup of an entity by a user-supplied name string: `wet thoughts --on <name>`, `wet entity show
+<name>`, `wet entity edit <name>`, `wet entity rename <name> ...`, `wet entity relate/unrelate <name>
+--parent <name>`, and entity extraction from `[bracket]` mentions during `wet add`/`wet edit`/`wet entity
+edit`'s description text.
+
+## Participants
+
+- `storage/entities_repository.rs` (`EntitiesRepository::resolve`, `find_by_name`)
+- `storage/entity_aliases_repository.rs` (`EntityAliasesRepository::find_entities_by_alias`)
+- `services/entity_resolution.rs` (`resolve_or_create_entity`, used by `add`/`edit`/`entity edit`)
+- `cli/entity_alias.rs` (`wet entity alias`/`unalias`, to manage the registry)
+- `storage/thoughts_repository.rs` (`list_by_entity`/`list_latest_by_entity`, which resolve their filter
+  root through this same path)
+
+## Step-by-step flow
+
+1. `EntitiesRepository::resolve(conn, name)` first checks for an exact, case-insensitive canonical-name
+   match (`find_by_name`). If found, it's returned immediately — a canonical name always wins, even if
+   some other entity also has that string registered as one of its aliases.
+2. If there's no canonical match, `EntityAliasesRepository::find_entities_by_alias(conn, name)` looks up
+   every entity that has `name` registered as an alias (case-insensitive):
+   - **Zero matches** → `resolve` returns `Ok(None)` — the name is unresolved.
+   - **Exactly one match** → `resolve` returns that entity.
+   - **Two or more matches** (the same alias string registered to different entities) → `resolve` returns
+     `Err(ThoughtError::AmbiguousAlias { alias, entities })`, naming every candidate's canonical name.
+3. Direct lookup call sites (`entity show`/`edit`/`rename`/`relate`/`unrelate`) propagate `AmbiguousAlias`
+   as a hard error via `?`, same as `EntityNotFound`.
+4. `ThoughtsRepository::list_by_entity`/`list_latest_by_entity` can't call `resolve` from inside raw SQL,
+   so they resolve the filter root in Rust first, then seed their `WITH RECURSIVE reachable(id)` CTE with
+   the resolved entity's id instead of a `WHERE name = ?1` clause. An unresolved name still returns an
+   empty result (preserving the pre-alias contract); an ambiguous alias now returns `AmbiguousAlias`
+   instead of silently matching nothing.
+5. `[bracket]` mention extraction (`add`/`edit`/`entity edit`) goes through
+   `entity_resolution::resolve_or_create_entity` instead of calling `resolve` directly, since this path has
+   a third possible outcome beyond found/not-found/ambiguous: an unresolved name falls back to creating a
+   brand-new literal entity (the pre-alias behavior, unchanged). An ambiguous match prints a warning to
+   stderr and skips linking that one mention — it does not fail the surrounding `add`/`edit`, and it does
+   not fall back to creating a literal entity for the ambiguous string.
+
+## Data and state changes
+
+None by itself — this is a read path. `wet entity alias`/`unalias` (see [`../systems/cli.md`](../systems/cli.md))
+are what mutate the `entity_aliases` table this flow reads from.
+
+## Success behavior
+
+A name resolves to exactly one entity if it's that entity's canonical name, or an alias registered to
+exactly one entity. Filtering, showing, editing, renaming, relating, and linking a `[bracket]` mention all
+behave identically whether the user typed the canonical name or a registered alias.
+
+## Failure behavior
+
+- Direct lookups (`entity show`/`edit`/`rename`/`relate`/`unrelate`, `thoughts --on`): an unresolvable name
+  → `ThoughtError::EntityNotFound` (unchanged from before aliases existed); a name matching more than one
+  entity's alias → `ThoughtError::AmbiguousAlias`, naming every candidate.
+- `[bracket]` mention extraction (`add`/`edit`/`entity edit`): an unresolvable name creates a new entity
+  (unchanged); an ambiguous alias prints a warning to stderr, skips linking that mention, and otherwise
+  completes normally — the whole command still succeeds.
+
+## External dependencies
+
+None.
+
+## Invariants and assumptions
+
+- A canonical entity name can never be shadowed by an alias — `resolve` always checks canonical names
+  first. `wet entity rename` separately guards against creating a *new* shadowing situation (see
+  [`entity-rename.md`](entity-rename.md)).
+- Aliases are unique per entity, not globally (`PRIMARY KEY (entity_id, alias)`) — the same alias string
+  may legitimately be registered to more than one entity, and ambiguity is an expected, handled outcome,
+  not a bug.
+- `resolve_or_create_entity`'s ambiguous-mention warning is the only place in `add`/`edit`/`entity edit`
+  where entity extraction has ever printed a warning — entity extraction elsewhere in those commands is
+  otherwise infallible.
+
+## Security and privacy notes
+
+Not applicable beyond general local-data sensitivity noted in [`../systems/storage.md`](../systems/storage.md).
+
+## Observability and debugging
+
+If a `[bracket]` mention silently isn't linked to any entity after `add`/`edit`, check stderr for an
+"matches multiple entities" warning — this is the ambiguous-alias skip path, not a crash.
+
+## Testing notes
+
+Cover: canonical-name match wins over a conflicting alias; unambiguous alias match; unresolved name;
+ambiguous alias match (`AmbiguousAlias`, sorted candidate list); `--on` filtering by alias matches filtering
+by canonical name; `--on` filtering by an ambiguous alias errors; unresolved `--on` name still returns
+empty (not an error); `resolve_or_create_entity`'s three outcomes (create-new, resolve-existing,
+skip-with-warning-on-ambiguity) via both unit tests and `add`/`edit` integration tests.
+
+## Source map
+
+- [`src/storage/entities_repository.rs`](../../src/storage/entities_repository.rs)
+- [`src/storage/entity_aliases_repository.rs`](../../src/storage/entity_aliases_repository.rs)
+- [`src/services/entity_resolution.rs`](../../src/services/entity_resolution.rs)
+- [`src/cli/entity_alias.rs`](../../src/cli/entity_alias.rs)
+- [`src/storage/thoughts_repository.rs`](../../src/storage/thoughts_repository.rs)
+
+## Related docs
+
+- [`../systems/storage.md`](../systems/storage.md), [`../systems/services.md`](../systems/services.md),
+  [`../systems/cli.md`](../systems/cli.md)
+- [`entity-rename.md`](entity-rename.md)
+- [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)
+- [`../architecture/decisions/0004-entity-reference-aliases.md`](../architecture/decisions/0004-entity-reference-aliases.md)

--- a/docs/flows/entity-rename.md
+++ b/docs/flows/entity-rename.md
@@ -20,11 +20,17 @@ entities' descriptions) pointing at the new name, without touching the underlyin
 
 1. Validate `new_name`: non-empty, and contains none of `[`, `]`, `(`, `)` (these would break entity
    reference syntax — see [`../systems/services.md`](../systems/services.md)).
-2. Confirm the entity exists (`EntitiesRepository::find_by_name`) — errors `EntityNotFound` if not.
-3. Confirm `new_name` doesn't collide with a *different* existing entity — errors `EntityAlreadyExists` if
-   so. The collision check compares entity IDs, so renaming an entity to itself, or only changing its
-   casing, is allowed.
-4. In a single `conn.transaction()`:
+2. Confirm the entity exists (`EntitiesRepository::resolve`, so `entity_name` may itself be an existing
+   alias — see [`entity-alias-resolution.md`](entity-alias-resolution.md)) — errors `EntityNotFound` if
+   not.
+3. Confirm `new_name` doesn't collide with a *different* existing entity's canonical name — errors
+   `EntityAlreadyExists` if so. The collision check compares entity IDs, so renaming an entity to itself,
+   or only changing its casing, is allowed.
+4. Confirm `new_name` isn't already registered as an alias of a *different* entity — errors
+   `RenameCollidesWithAlias` if so (renaming to the same entity's own alias is fine). Without this guard,
+   `resolve()`'s canonical-wins-first rule would let the rename silently and permanently shadow that other
+   entity's alias.
+5. In a single `conn.transaction()`:
    - Rewrite every other entity's description text via `entity_parser::rewrite_entity_references`.
    - Rewrite every linked thought's content the same way.
    - Rename the entity row itself (`name` + `canonical_name`).
@@ -44,7 +50,10 @@ thought↔entity links remain intact.
 ## Failure behavior
 
 - Entity not found → `ThoughtError::EntityNotFound`, no changes made.
-- New name collides with a different entity → `ThoughtError::EntityAlreadyExists`, no changes made.
+- New name collides with a different entity's canonical name → `ThoughtError::EntityAlreadyExists`, no
+  changes made.
+- New name is already registered as a different entity's alias → `ThoughtError::RenameCollidesWithAlias`,
+  no changes made.
 - New name contains reserved characters → `ThoughtError::InvalidInput`, no changes made, no transaction
   opened.
 
@@ -72,8 +81,9 @@ formatting that the `ENTITY_PATTERN` regex wouldn't have matched in the first pl
 ## Testing notes
 
 Cover: rename with existing bare references, rename with aliased references (alias text preserved, target
-rewritten), rename to an existing different entity's name (collision error), case-only rename (allowed),
-rename of a nonexistent entity.
+rewritten), rename to an existing different entity's name (collision error), rename to a different
+entity's registered alias (`RenameCollidesWithAlias`), rename to the entity's own alias (allowed),
+case-only rename (allowed), rename looked up by alias, rename of a nonexistent entity.
 
 ## Source map
 
@@ -86,4 +96,6 @@ rename of a nonexistent entity.
 
 - [`../systems/cli.md`](../systems/cli.md), [`../systems/services.md`](../systems/services.md),
   [`../systems/storage.md`](../systems/storage.md)
+- [`entity-alias-resolution.md`](entity-alias-resolution.md)
 - [`../architecture/decisions/0010-entity-rename.md`](../architecture/decisions/0010-entity-rename.md)
+- [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)

--- a/docs/glossary.md
+++ b/docs/glossary.md
@@ -30,8 +30,20 @@ The bracket markup used inside Thought content and Entity descriptions to link t
 ## Alias
 
 The display text in an aliased Entity Reference `[alias](entity)` — shown in place of the entity's name,
-while the reference still resolves to and links the named entity. See
+while the reference still resolves to and links the named entity. Not to be confused with **Known Alias**
+below — this is free-form, per-occurrence display text, not a persisted association. See
 [`architecture/decisions/0004-entity-reference-aliases.md`](architecture/decisions/0004-entity-reference-aliases.md).
+
+## Known Alias
+
+A persisted alternate name registered for an Entity (`wet entity alias`/`unalias`), resolving to that
+Entity anywhere a name is looked up — filtering, `entity show`, and `[bracket]` mentions alike. Unique per
+entity, not globally: the same alias string may be registered to more than one Entity, in which case
+resolving it is ambiguous and errors rather than guessing. Not to be confused with the pre-existing
+**Alias** term above (a different, unrelated concept despite the shared word). See
+[`systems/storage.md`](systems/storage.md),
+[`flows/entity-alias-resolution.md`](flows/entity-alias-resolution.md), and
+[`architecture/decisions/0013-entity-aliases.md`](architecture/decisions/0013-entity-aliases.md).
 
 ## Description Preview
 

--- a/docs/systems/cli.md
+++ b/docs/systems/cli.md
@@ -43,6 +43,8 @@ Global `--color` flag (`ColorMode`, see [`services.md`](services.md)). Subcomman
 | `entity show` | `entity_name` | Show description, parents/children, + 5 latest linked thoughts (including descendants') | `cli/entity_show.rs` |
 | `entity relate` | `entity_name`, `--parent <name>` | Mark `entity_name` as a child of `--parent` | `cli/entity_relate.rs` |
 | `entity unrelate` | `entity_name`, `--parent <name>` | Remove that parent/child relation | `cli/entity_relate.rs` |
+| `entity alias` | `entity_name`, `--alias <x>` | Register an alternate name for an entity | `cli/entity_alias.rs` |
+| `entity unalias` | `entity_name`, `--alias <x>` | Remove a previously-registered alias | `cli/entity_alias.rs` |
 
 **Common pattern**: every command's `execute(...)` opens its own `Connection`, calls
 `storage::run_migrations`, performs its repository/service calls, and prints output — usually through
@@ -52,11 +54,16 @@ commands (see [`storage.md`](storage.md)).
 **Notable per-command detail:**
 
 - `add.rs` — parses `--date` (`NaiveDate` "%Y-%m-%d" → midnight UTC) if given, saves the thought, then
-  extracts entities via `entity_parser::extract_unique_entities` and `find_or_create`s + links each.
+  extracts entities via `entity_parser::extract_unique_entities` and resolves each via
+  `entity_resolution::resolve_or_create_entity` (registered aliases resolve to their entity; unresolved
+  names still `find_or_create`; ambiguous aliases skip linking with a warning — see
+  [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)) before linking.
 - `thoughts.rs` — repository always returns ascending order; the command reverses the list if
   `SortOrder::Descending`. `--on <entity>` filtering includes thoughts tagged on any entity transitively
   reachable from `<entity>` via child relations, not just `<entity>` itself (see
-  [`../architecture/decisions/0012-entity-relations.md`](../architecture/decisions/0012-entity-relations.md)).
+  [`../architecture/decisions/0012-entity-relations.md`](../architecture/decisions/0012-entity-relations.md)),
+  and `<entity>` may be a registered alias as well as a canonical name (see
+  [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)).
 - `edit.rs` — see [`flows/edit-thought.md`](../flows/edit-thought.md). If `--editor` is used and the
   editor process exits abnormally, this prints a warning and returns `Ok(())` — **no error is propagated
   and no changes are made** (see Common Pitfalls).
@@ -70,22 +77,32 @@ commands (see [`storage.md`](storage.md)).
   `description_formatter::generate_preview` alongside the name.
 - `entity_edit.rs` — three mutually exclusive input modes: inline `--description`, `--description-file`,
   or interactive editor (none of the flags given). Trimmed-empty input means "remove the description".
-  Verifies the entity exists first, with a hint to create it via `wet add` if not. Auto-creates any
-  entities newly referenced *within* the description text itself.
+  Verifies the entity exists first (alias-aware, via `EntitiesRepository::resolve`), with a hint to create
+  it via `wet add` if not; subsequent calls like `update_description` use the *resolved* canonical name,
+  not the raw (possibly alias) argument. Resolves/auto-creates any entities newly referenced *within* the
+  description text itself via `entity_resolution::resolve_or_create_entity`.
 - `entity_rename.rs` — see [`flows/entity-rename.md`](../flows/entity-rename.md). Validates `new_name` is
   non-empty and contains none of `[`, `]`, `(`, `)` (these would break entity-reference parsing, see
-  [`services.md`](services.md)).
-- `entity_show.rs` — prints canonical name, styled description (if any), direct (non-transitive)
-  `Parents:`/`Children:` lines when the entity has any, and up to 5 most recent linked thoughts
-  (`LATEST_THOUGHTS_LIMIT = 5`) — this list now includes thoughts tagged on any entity transitively
-  reachable via child relations, not just the entity itself (see
+  [`services.md`](services.md)). The entity to rename is looked up alias-aware (`resolve`); the new name is
+  checked against both other entities' canonical names (`EntityAlreadyExists`) and other entities'
+  registered aliases (`RenameCollidesWithAlias`).
+- `entity_show.rs` — prints canonical name, styled description (if any), an `Aliases: ...` line when the
+  entity has any registered aliases, direct (non-transitive) `Parents:`/`Children:` lines when the entity
+  has any, and up to 5 most recent linked thoughts (`LATEST_THOUGHTS_LIMIT = 5`) — this list now includes
+  thoughts tagged on any entity transitively reachable via child relations, not just the entity itself (see
   [`../architecture/decisions/0012-entity-relations.md`](../architecture/decisions/0012-entity-relations.md)).
+  `entity_name` may itself be a registered alias.
 - `entity_relate.rs` — holds both `execute_relate` and `execute_unrelate` (small, symmetric operations
   sharing entity-resolution logic, unlike the one-file-per-command precedent elsewhere in `cli/`). Both
-  entities must already exist. `relate` rejects self-relation (`ThoughtError::SelfRelation`) and any
-  relation that would create a cycle (`ThoughtError::RelationCycle`, checked via
-  `EntityRelationsRepository::would_create_cycle` before inserting, inside a transaction). `unrelate` is
-  idempotent — removing a relation that doesn't exist succeeds silently.
+  entities must already exist (looked up alias-aware). `relate` rejects self-relation
+  (`ThoughtError::SelfRelation`) and any relation that would create a cycle (`ThoughtError::RelationCycle`,
+  checked via `EntityRelationsRepository::would_create_cycle` before inserting, inside a transaction).
+  `unrelate` is idempotent — removing a relation that doesn't exist succeeds silently.
+- `entity_alias.rs` — holds both `execute_alias` and `execute_unalias`, structurally identical to
+  `entity_relate.rs`. Both resolve `entity_name` alias-aware (so an entity can be referenced by one of its
+  *other* existing aliases too), reject an empty `--alias` value, and are idempotent (registering an
+  already-registered alias, or removing a never-registered one, both succeed silently). See
+  [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md).
 - `tui.rs` — loads all thoughts+entities, calls `ratatui::init()`, builds `tui::App`, runs the event loop,
   then **always** calls `ratatui::restore()` after, even if the loop returned an error (terminal state is
   restored before the error propagates further).
@@ -94,6 +111,7 @@ commands (see [`storage.md`](storage.md)).
 
 - [`flows/edit-thought.md`](../flows/edit-thought.md)
 - [`flows/entity-rename.md`](../flows/entity-rename.md)
+- [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)
 
 Thought deletion (CLI `wet delete`, no confirmation, vs. TUI `x` + confirm overlay) is covered inline here
 and in [`tui.md`](tui.md), rather than as a standalone flow doc — the two paths are simple and short
@@ -111,8 +129,8 @@ storage.
 
 ## Dependencies
 
-`errors`, `models`, `services::{color_mode, description_formatter, entity_parser, entity_styler}`,
-`storage::*`, `input::editor`, `config`, `tui::App` (only `cli/tui.rs`).
+`errors`, `models`, `services::{color_mode, description_formatter, entity_parser, entity_resolution,
+entity_styler}`, `storage::*`, `input::editor`, `config`, `tui::App` (only `cli/tui.rs`).
 
 ## Downstream effects
 
@@ -172,9 +190,12 @@ bypassing actual CLI argument parsing.
 - [`src/cli/entity_edit.rs`](../../src/cli/entity_edit.rs)
 - [`src/cli/entity_rename.rs`](../../src/cli/entity_rename.rs)
 - [`src/cli/entity_show.rs`](../../src/cli/entity_show.rs)
+- [`src/cli/entity_alias.rs`](../../src/cli/entity_alias.rs)
 
 ## Related docs
 
 - [`storage.md`](storage.md), [`services.md`](services.md), [`tui.md`](tui.md), [`input.md`](input.md)
-- [`flows/edit-thought.md`](../flows/edit-thought.md), [`flows/entity-rename.md`](../flows/entity-rename.md)
+- [`flows/edit-thought.md`](../flows/edit-thought.md), [`flows/entity-rename.md`](../flows/entity-rename.md),
+  [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)
 - [`../architecture/decisions/0008-delete-thoughts.md`](../architecture/decisions/0008-delete-thoughts.md)
+- [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)

--- a/docs/systems/models.md
+++ b/docs/systems/models.md
@@ -78,6 +78,9 @@ validation change here ripples everywhere.
 - Thought content is always non-empty and ≤10,000 characters by the time it reaches storage — enforced
   at construction, not at the storage layer.
 - `Entity::name` is always the lowercased form of `canonical_name`.
+- An entity may have zero or more registered aliases, but these are **not** an `Entity` struct field — they
+  live in a separate table/repository (`entity_aliases` / `EntityAliasesRepository`, see
+  [`storage.md`](storage.md)) and are only loaded on demand.
 
 ## Error handling
 

--- a/docs/systems/services.md
+++ b/docs/systems/services.md
@@ -3,8 +3,9 @@
 ## Purpose
 
 Pure business-logic helpers with no I/O or persistence dependencies — entity-reference parsing, entity
-color styling, description-preview formatting, and terminal color-mode detection. Reused by both the CLI
-and the TUI.
+color styling, description-preview formatting, and terminal color-mode detection — plus one small
+DB-touching helper, `entity_resolution`, that ties `[bracket]` mention extraction to the persisted alias
+registry. Reused by both the CLI and the TUI.
 
 ## Questions this doc answers
 
@@ -15,7 +16,8 @@ and the TUI.
 
 ## Scope
 
-`src/services/color_mode.rs`, `entity_parser.rs`, `entity_styler.rs`, `description_formatter.rs`.
+`src/services/color_mode.rs`, `entity_parser.rs`, `entity_styler.rs`, `description_formatter.rs`,
+`entity_resolution.rs`.
 
 ## Non-scope
 
@@ -47,6 +49,23 @@ needs to find or rewrite entity references in text:
   aliased `[Alias](old)` → `[Alias](New)`, leaving alias display text and unrelated references untouched.
   Used by entity rename (see [`flows/entity-rename.md`](../flows/entity-rename.md)).
 
+Note: this module's "aliased syntax" (`[alias](entity)`) is unrelated to the persisted alias registry
+described below and in [`storage.md`](storage.md) — it's free-form, per-occurrence *display* text that
+never touches `entity_aliases`, and `extract_entities` always resolves it to the parenthesized *target*
+name directly, without consulting the registry. See
+[`../architecture/decisions/0004-entity-reference-aliases.md`](../architecture/decisions/0004-entity-reference-aliases.md)
+and [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)
+for the distinction.
+
+**`entity_resolution.rs`** — `resolve_or_create_entity(conn, name) -> Result<Option<i64>, ThoughtError>`,
+the one function in this module that touches storage. Used by `add`/`edit`/`entity edit` wherever they
+used to unconditionally `find_or_create` an extracted `[bracket]` name: it resolves `name` against
+canonical names and registered aliases first (`EntitiesRepository::resolve`), only falling back to
+creating a brand-new literal entity when nothing matches. If `name` is an alias registered to more than
+one entity, it prints a warning to stderr and returns `Ok(None)` — the mention is skipped (not linked to
+any entity, no new entity created) without failing the caller's overall command. See
+[`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md).
+
 **`entity_styler.rs`** — `EntityStyler { color_map, next_color, use_colors }`. Cycles through a 12-color
 palette (excluding black/white). `EntityStyler::new(use_colors)`, `render_content(&mut self, content) ->
 String` — strips entity markup and, if `use_colors`, colors+bolds each entity span. Color assignment is
@@ -76,8 +95,11 @@ rewrite_entity_references}`, `EntityStyler::{new, render_content}`,
 
 ## Dependencies
 
-`errors` (indirectly), `regex`, `owo-colors`, `terminal_size`. No dependency on `storage` or `cli` — this
-is what makes these services reusable by the TUI as well.
+`errors` (indirectly), `regex`, `owo-colors`, `terminal_size`. No dependency on `storage` or `cli` for
+`color_mode`/`entity_parser`/`entity_styler`/`description_formatter` — this is what makes those services
+reusable by the TUI as well. `entity_resolution` is the one exception: it depends on `storage` directly
+(`EntitiesRepository`, `EntityAliasesRepository`) since resolving a name against the alias registry
+requires a database read.
 
 ## Downstream effects
 
@@ -132,3 +154,5 @@ bare references, nested-looking brackets) and the preview pipeline's truncation 
 - [`cli.md`](cli.md), [`tui.md`](tui.md) — consumers.
 - [`flows/entity-rename.md`](../flows/entity-rename.md)
 - [Glossary: Entity Reference, Alias, Color Mode, Description Preview](../glossary.md)
+- [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)
+- [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)

--- a/docs/systems/storage.md
+++ b/docs/systems/storage.md
@@ -2,9 +2,9 @@
 
 ## Purpose
 
-SQLite persistence for Thoughts and Entities: connection handling, schema migrations, and the two
-repositories (`ThoughtsRepository`, `EntitiesRepository`) every other system goes through to read or
-write data.
+SQLite persistence for Thoughts and Entities: connection handling, schema migrations, and the
+repositories (`ThoughtsRepository`, `EntitiesRepository`, `EntityRelationsRepository`,
+`EntityAliasesRepository`) every other system goes through to read or write data.
 
 ## Questions this doc answers
 
@@ -16,7 +16,7 @@ write data.
 ## Scope
 
 `src/storage/connection.rs`, `data_dir.rs`, `migrations/`, `entities_repository.rs`,
-`thoughts_repository.rs`, `entity_relations_repository.rs`.
+`thoughts_repository.rs`, `entity_relations_repository.rs`, `entity_aliases_repository.rs`.
 
 ## Non-scope
 
@@ -48,8 +48,9 @@ a real user's data. `ensure_data_dir(path)` creates the directory. `default_db_p
 1. `networked_notes_migration::migrate` — creates the base schema (below).
 2. `add_entity_descriptions_migration::migrate_add_entity_descriptions` — adds `entities.description`.
 3. `entity_relations_migration::migrate` — creates `entity_relations` (below).
+4. `entity_aliases_migration::migrate` — creates `entity_aliases` (below).
 
-Both are **idempotent**: `CREATE TABLE IF NOT EXISTS` and a `pragma_table_info` column-existence check
+All are **idempotent**: `CREATE TABLE IF NOT EXISTS` and a `pragma_table_info` column-existence check
 before adding a column. There is **no migration-version tracking table** — idempotency is the entire
 safety net, and the pattern is strictly additive (no down-migrations). Because every command calls
 `run_migrations` before doing anything else, the schema is always brought up to date on first use, at the
@@ -92,7 +93,22 @@ CREATE TABLE IF NOT EXISTS entity_relations (
 );
 CREATE INDEX IF NOT EXISTS idx_entity_relations_parent ON entity_relations(parent_id);
 CREATE INDEX IF NOT EXISTS idx_entity_relations_child ON entity_relations(child_id);
+
+CREATE TABLE IF NOT EXISTS entity_aliases (
+    entity_id INTEGER NOT NULL,
+    alias TEXT NOT NULL COLLATE NOCASE CHECK(length(trim(alias)) > 0),
+    PRIMARY KEY (entity_id, alias),
+    FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+);
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias ON entity_aliases(alias);
+CREATE INDEX IF NOT EXISTS idx_entity_aliases_entity ON entity_aliases(entity_id);
 ```
+
+`entity_aliases` associates alternate names with an entity; `PRIMARY KEY (entity_id, alias)` makes an
+alias unique *per entity*, not globally — the same alias string may be registered to more than one entity,
+so resolution must handle ambiguity (see [`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)
+and [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)).
+`alias` is `COLLATE NOCASE`, matching `entities.name`'s case-insensitivity convention.
 
 `entity_relations` is a directed edge table (`child_id` → `parent_id`) forming a DAG — an entity may have
 multiple parents. The `CHECK (child_id != parent_id)` constraint prevents direct self-relations at the DB
@@ -111,19 +127,33 @@ for why this normalized shape was chosen.
 objects:
 
 `EntitiesRepository`: `find_or_create`, `link_to_thought` (`INSERT OR IGNORE`), `find_by_name`
-(case-insensitive), `list_all` (alphabetical by `canonical_name`), `unlink_all_from_thought`,
-`update_description` (errors `EntityNotFound` if absent), `rename` (updates `name`+`canonical_name`,
-errors `EntityNotFound`/`EntityAlreadyExists`; the collision check compares entity IDs, so a self-rename
-or case-only casing change is allowed).
+(case-insensitive, canonical name only), `resolve` (canonical name first, falling back to
+`EntityAliasesRepository::find_entities_by_alias` — see
+[`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md); returns
+`Err(AmbiguousAlias)` if the alias matches more than one entity), `list_all` (alphabetical by
+`canonical_name`), `unlink_all_from_thought`, `update_description` (errors `EntityNotFound` if absent),
+`rename` (updates `name`+`canonical_name`, errors `EntityNotFound`/`EntityAlreadyExists`; the collision
+check compares entity IDs, so a self-rename or case-only casing change is allowed). Most call sites that
+used to call `find_by_name` for user-facing name lookups now call `resolve` instead, so they also accept
+aliases; `find_by_name` itself is kept for call sites that deliberately want canonical-only semantics
+(e.g. `entity rename`'s new-name collision check).
+
+`EntityAliasesRepository`: `add_alias(entity_id, alias)` (`INSERT OR IGNORE` — idempotent; rejects an
+empty/whitespace-only alias explicitly, since `INSERT OR IGNORE` would otherwise silently suppress the
+table's `CHECK` constraint too), `remove_alias` (`DELETE` — idempotent/no-op-safe), `list_for_entity`
+(alphabetical), `find_entities_by_alias` (case-insensitive; may return more than one entity, since aliases
+are unique per entity, not globally).
 
 `ThoughtsRepository`: `save` (stores `created_at` as an RFC3339 string), `get_by_id`, `list_all`
 (chronological ascending), `update` (errors `ThoughtNotFound` if zero rows affected), `delete` (errors
 `ThoughtNotFound` if zero rows affected; relies on `ON DELETE CASCADE` for `thought_entities` cleanup),
 `list_by_entity`, `list_latest_by_entity(limit)` (joins `thought_entities`/`entities`, `ORDER BY
-created_at DESC LIMIT`). **Both `list_by_entity` and `list_latest_by_entity` are reachability-aware**: each
-opens with a `WITH RECURSIVE reachable(id) AS (...)` CTE that starts at the named entity and follows
-`entity_relations` child edges downward, then joins `thought_entities` against that CTE instead of
-against a single entity ID directly — so both return thoughts tagged on the named entity *and* every
+created_at DESC LIMIT`). **Both `list_by_entity` and `list_latest_by_entity` are reachability- and
+alias-aware**: each first resolves the given name via `EntitiesRepository::resolve` (returning empty
+results for an unresolved name, or propagating `AmbiguousAlias` if the name matches more than one entity's
+alias), then seeds a `WITH RECURSIVE reachable(id) AS (...)` CTE with the resolved entity's id and follows
+`entity_relations` child edges downward from there, joining `thought_entities` against that CTE instead of
+against a single entity ID directly — so both return thoughts tagged on the resolved entity *and* every
 entity transitively reachable from it via child relations (its descendants), with no separate round trip
 or dynamic `IN (...)` list. `DISTINCT` in the `SELECT` prevents a thought reachable via more than one path
 in a diamond-shaped DAG from appearing twice.
@@ -164,7 +194,8 @@ The SQLite database file at the resolved db path (default `<data_dir>/default.db
 ## Interfaces and entry points
 
 `get_connection`, `get_memory_connection`, `resolve_data_dir`, `ensure_data_dir`, `default_db_path_in`,
-`run_migrations`, `EntitiesRepository::*`, `ThoughtsRepository::*`, `EntityRelationsRepository::*`.
+`run_migrations`, `EntitiesRepository::*`, `ThoughtsRepository::*`, `EntityRelationsRepository::*`,
+`EntityAliasesRepository::*`.
 
 ## Dependencies
 
@@ -190,7 +221,9 @@ requires a new, idempotent migration — never edit an existing migration once i
 
 `update`/`delete` on `ThoughtsRepository` return `ThoughtError::ThoughtNotFound` when zero rows are
 affected (not a SQLite-level error — checked explicitly). `EntitiesRepository::rename`/
-`update_description` return `EntityNotFound`/`EntityAlreadyExists` similarly.
+`update_description` return `EntityNotFound`/`EntityAlreadyExists` similarly. `EntitiesRepository::resolve`
+returns `AmbiguousAlias` when a name matches more than one entity's registered alias, rather than picking
+one arbitrarily.
 
 ## Security and privacy notes
 
@@ -227,6 +260,8 @@ migrations use internally to check for existing columns, useful for manually ver
 - [`src/storage/thoughts_repository.rs`](../../src/storage/thoughts_repository.rs)
 - [`src/storage/entity_relations_repository.rs`](../../src/storage/entity_relations_repository.rs)
 - [`src/storage/migrations/entity_relations_migration.rs`](../../src/storage/migrations/entity_relations_migration.rs)
+- [`src/storage/entity_aliases_repository.rs`](../../src/storage/entity_aliases_repository.rs)
+- [`src/storage/migrations/entity_aliases_migration.rs`](../../src/storage/migrations/entity_aliases_migration.rs)
 
 ## Related docs
 
@@ -235,3 +270,5 @@ migrations use internally to check for existing columns, useful for manually ver
 - [`../architecture/decisions/0001-networked-notes-schema.md`](../architecture/decisions/0001-networked-notes-schema.md)
 - [`../architecture/decisions/0007-data-directory.md`](../architecture/decisions/0007-data-directory.md)
 - [`../architecture/decisions/0012-entity-relations.md`](../architecture/decisions/0012-entity-relations.md)
+- [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)
+- [`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,8 +1,7 @@
 /// Add command implementation
 use crate::errors::ThoughtError;
-use crate::models::entity::Entity;
 use crate::models::thought::Thought;
-use crate::services::entity_parser;
+use crate::services::{entity_parser, entity_resolution};
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
@@ -35,9 +34,9 @@ pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<
     // Extract and save entities
     let entity_names = entity_parser::extract_unique_entities(&content);
     for entity_name in &entity_names {
-        let entity = Entity::new(entity_name.clone());
-        let entity_id = EntitiesRepository::find_or_create(&conn, &entity)?;
-        EntitiesRepository::link_to_thought(&conn, entity_id, thought_id)?;
+        if let Some(entity_id) = entity_resolution::resolve_or_create_entity(&conn, entity_name)? {
+            EntitiesRepository::link_to_thought(&conn, entity_id, thought_id)?;
+        }
     }
 
     // Success message with entity count

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -1,8 +1,7 @@
 /// Edit command implementation
 use crate::errors::ThoughtError;
 use crate::input::editor;
-use crate::models::entity::Entity;
-use crate::services::entity_parser;
+use crate::services::{entity_parser, entity_resolution};
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
@@ -104,9 +103,9 @@ pub fn execute(
         EntitiesRepository::unlink_all_from_thought(&tx, id)?;
         let entity_names = entity_parser::extract_unique_entities(final_content);
         for entity_name in &entity_names {
-            let entity = Entity::new(entity_name.clone());
-            let entity_id = EntitiesRepository::find_or_create(&tx, &entity)?;
-            EntitiesRepository::link_to_thought(&tx, entity_id, id)?;
+            if let Some(entity_id) = entity_resolution::resolve_or_create_entity(&tx, entity_name)? {
+                EntitiesRepository::link_to_thought(&tx, entity_id, id)?;
+            }
         }
     }
 

--- a/src/cli/entity_alias.rs
+++ b/src/cli/entity_alias.rs
@@ -1,0 +1,195 @@
+/// Entity alias/unalias command implementations
+use crate::errors::ThoughtError;
+use crate::storage::connection::get_connection;
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+use crate::storage::migrations::run_migrations;
+use rusqlite::Connection;
+use std::path::Path;
+
+fn require_entity(conn: &Connection, name: &str) -> Result<crate::models::entity::Entity, ThoughtError> {
+    EntitiesRepository::resolve(conn, name)?.ok_or_else(|| {
+        eprintln!("Error: Entity '{}' not found", name);
+        eprintln!();
+        eprintln!("Hint: Create the entity first by referencing it in a thought:");
+        eprintln!("  wet add \"Learning about [{}] today\"", name);
+        ThoughtError::EntityNotFound(name.to_string())
+    })
+}
+
+/// Execute the entity alias command
+///
+/// Registers `alias` as an alternate name for `entity_name`, resolving everywhere the
+/// entity is looked up by name (filtering, `entity show`, thought/description mentions,
+/// etc). Idempotent: registering an already-registered alias succeeds without error.
+/// The same alias may be registered for more than one entity - aliases are unique per
+/// entity, not globally.
+///
+/// # Arguments
+/// * `entity_name` - Entity to register the alias for (case-insensitive; may itself be
+///   an existing alias)
+/// * `alias` - Alias to register
+/// * `db_path` - Database path
+pub fn execute_alias(entity_name: &str, alias: &str, db_path: &Path) -> Result<(), ThoughtError> {
+    if alias.trim().is_empty() {
+        return Err(ThoughtError::InvalidInput("Alias cannot be empty".to_string()));
+    }
+
+    let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let entity = require_entity(&conn, entity_name)?;
+
+    EntityAliasesRepository::add_alias(&conn, entity.id.unwrap(), alias)?;
+
+    println!("Alias '{}' added for entity '{}'.", alias, entity.canonical_name);
+
+    Ok(())
+}
+
+/// Execute the entity unalias command
+///
+/// Removes `alias` from `entity_name`. Idempotent: succeeds even if the alias wasn't
+/// registered.
+///
+/// # Arguments
+/// * `entity_name` - Entity to remove the alias from (case-insensitive; may itself be
+///   an existing alias)
+/// * `alias` - Alias to remove
+/// * `db_path` - Database path
+pub fn execute_unalias(entity_name: &str, alias: &str, db_path: &Path) -> Result<(), ThoughtError> {
+    let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+
+    let entity = require_entity(&conn, entity_name)?;
+
+    EntityAliasesRepository::remove_alias(&conn, entity.id.unwrap(), alias)?;
+
+    println!("Alias '{}' removed from entity '{}'.", alias, entity.canonical_name);
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::entity::Entity;
+    use tempfile::TempDir;
+
+    fn setup_entity(conn: &Connection, name: &str) {
+        let entity = Entity::new(name.to_string());
+        EntitiesRepository::find_or_create(conn, &entity).unwrap();
+    }
+
+    fn temp_db_with_entities(names: &[&str]) -> (TempDir, std::path::PathBuf) {
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+
+        let conn = get_connection(&db_path).unwrap();
+        run_migrations(&conn).unwrap();
+        for name in names {
+            setup_entity(&conn, name);
+        }
+
+        (temp_dir, db_path)
+    }
+
+    #[test]
+    fn test_execute_alias_creates_alias() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        let result = execute_alias("Sarah", "sar", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let sarah = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah.id.unwrap()).unwrap();
+        assert_eq!(aliases, vec!["sar"]);
+    }
+
+    #[test]
+    fn test_execute_alias_missing_entity_errors() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&[]);
+
+        let result = execute_alias("Sarah", "sar", &db_path);
+        assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "Sarah"));
+    }
+
+    #[test]
+    fn test_execute_alias_idempotent() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        assert!(execute_alias("Sarah", "sar", &db_path).is_ok());
+        assert!(execute_alias("Sarah", "sar", &db_path).is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let sarah = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah.id.unwrap()).unwrap();
+        assert_eq!(aliases.len(), 1);
+    }
+
+    #[test]
+    fn test_execute_alias_empty_alias_rejected() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        let result = execute_alias("Sarah", "  ", &db_path);
+        assert!(matches!(result, Err(ThoughtError::InvalidInput(_))));
+    }
+
+    #[test]
+    fn test_execute_alias_same_alias_two_entities_both_succeed() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah", "John"]);
+
+        assert!(execute_alias("Sarah", "boss", &db_path).is_ok());
+        assert!(execute_alias("John", "boss", &db_path).is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "boss").unwrap();
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn test_execute_alias_by_existing_alias_name() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        execute_alias("Sarah", "sar", &db_path).unwrap();
+        // Register a second alias by referencing the entity via its first alias.
+        let result = execute_alias("sar", "sarita", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let sarah = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah.id.unwrap()).unwrap();
+        assert_eq!(aliases, vec!["sar", "sarita"]);
+    }
+
+    #[test]
+    fn test_execute_unalias_removes_alias() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        execute_alias("Sarah", "sar", &db_path).unwrap();
+        let result = execute_unalias("Sarah", "sar", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let sarah = EntitiesRepository::find_by_name(&conn, "sarah").unwrap().unwrap();
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah.id.unwrap()).unwrap();
+        assert!(aliases.is_empty());
+    }
+
+    #[test]
+    fn test_execute_unalias_nonexistent_alias_is_noop() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Sarah"]);
+
+        let result = execute_unalias("Sarah", "sar", &db_path);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_execute_unalias_requires_entity_to_exist() {
+        let (_temp_dir, db_path) = temp_db_with_entities(&[]);
+
+        let result = execute_unalias("Sarah", "sar", &db_path);
+        assert!(matches!(result, Err(ThoughtError::EntityNotFound(name)) if name == "Sarah"));
+    }
+}

--- a/src/cli/entity_edit.rs
+++ b/src/cli/entity_edit.rs
@@ -1,8 +1,7 @@
 /// Entity edit command implementation
 use crate::errors::ThoughtError;
 use crate::input::editor;
-use crate::models::entity::Entity;
-use crate::services::entity_parser;
+use crate::services::{entity_parser, entity_resolution};
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
@@ -48,15 +47,18 @@ pub fn execute(
     let conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 
-    // T030: Verify entity exists
-    let entity_opt = EntitiesRepository::find_by_name(&conn, entity_name)?;
-    if entity_opt.is_none() {
+    // T030: Verify entity exists (alias-aware, so `entity_name` may itself be an alias)
+    let entity_opt = EntitiesRepository::resolve(&conn, entity_name)?;
+    let Some(ref entity) = entity_opt else {
         eprintln!("Error: Entity '{}' not found", entity_name);
         eprintln!();
         eprintln!("Hint: Create the entity first by referencing it in a thought:");
         eprintln!("  wet add \"Learning about [{}] today\"", entity_name);
         return Err(ThoughtError::EntityNotFound(entity_name.to_string()));
-    }
+    };
+    // Resolved canonical (lowercase) name - subsequent repository calls that do their
+    // own canonical-only lookup must use this, not the raw (possibly alias) argument.
+    let resolved_name = entity.name.clone();
 
     // Get description text based on input method
     let description_text = if let Some(inline_desc) = description {
@@ -97,13 +99,12 @@ pub fn execute(
     if let Some(ref desc) = final_description {
         let referenced_entities = entity_parser::extract_unique_entities(desc);
         for ref_entity_name in referenced_entities {
-            let ref_entity = Entity::new(ref_entity_name);
-            EntitiesRepository::find_or_create(&conn, &ref_entity)?;
+            entity_resolution::resolve_or_create_entity(&conn, &ref_entity_name)?;
         }
     }
 
     // Update description in database
-    EntitiesRepository::update_description(&conn, entity_name, final_description.clone())?;
+    EntitiesRepository::update_description(&conn, &resolved_name, final_description.clone())?;
 
     // Print success message
     if final_description.is_some() {

--- a/src/cli/entity_relate.rs
+++ b/src/cli/entity_relate.rs
@@ -8,7 +8,7 @@ use rusqlite::Connection;
 use std::path::Path;
 
 fn resolve_entity(conn: &Connection, name: &str) -> Result<crate::models::entity::Entity, ThoughtError> {
-    let entity = EntitiesRepository::find_by_name(conn, name)?;
+    let entity = EntitiesRepository::resolve(conn, name)?;
     entity.ok_or_else(|| {
         eprintln!("Error: Entity '{}' not found", name);
         eprintln!();
@@ -106,6 +106,28 @@ mod tests {
         }
 
         (temp_dir, db_path)
+    }
+
+    #[test]
+    fn test_execute_relate_resolves_alias_on_both_sides() {
+        use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+
+        let (_temp_dir, db_path) = temp_db_with_entities(&["Amazon", "AWS"]);
+
+        let conn = get_connection(&db_path).unwrap();
+        let amazon = EntitiesRepository::find_by_name(&conn, "amazon").unwrap().unwrap();
+        let aws = EntitiesRepository::find_by_name(&conn, "aws").unwrap().unwrap();
+        EntityAliasesRepository::add_alias(&conn, amazon.id.unwrap(), "bigco").unwrap();
+        EntityAliasesRepository::add_alias(&conn, aws.id.unwrap(), "cloud").unwrap();
+        drop(conn);
+
+        let result = execute_relate("cloud", "bigco", &db_path);
+        assert!(result.is_ok());
+
+        let conn = get_connection(&db_path).unwrap();
+        let children = EntityRelationsRepository::list_children(&conn, amazon.id.unwrap()).unwrap();
+        assert_eq!(children.len(), 1);
+        assert_eq!(children[0].canonical_name, "AWS");
     }
 
     #[test]

--- a/src/cli/entity_rename.rs
+++ b/src/cli/entity_rename.rs
@@ -3,6 +3,7 @@ use crate::errors::ThoughtError;
 use crate::services::entity_parser::rewrite_entity_references;
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_aliases_repository::EntityAliasesRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 use std::path::Path;
@@ -39,7 +40,7 @@ pub fn execute(entity_name: &str, new_name: &str, db_path: &Path) -> Result<(), 
     let mut conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 
-    let entity = EntitiesRepository::find_by_name(&conn, entity_name)?;
+    let entity = EntitiesRepository::resolve(&conn, entity_name)?;
     let Some(entity) = entity else {
         eprintln!("Error: Entity '{}' not found", entity_name);
         eprintln!();
@@ -53,6 +54,20 @@ pub fn execute(entity_name: &str, new_name: &str, db_path: &Path) -> Result<(), 
     {
         eprintln!("Error: Entity '{}' already exists", new_name);
         return Err(ThoughtError::EntityAlreadyExists(new_name.to_string()));
+    }
+
+    // Renaming to a name that's already registered as some *other* entity's alias
+    // would silently shadow that alias in `resolve()` (canonical names always win),
+    // making it permanently unreachable via alias lookup with no visible signal.
+    if let Some(other) = EntityAliasesRepository::find_entities_by_alias(&conn, new_name)?
+        .into_iter()
+        .find(|e| e.id != entity.id)
+    {
+        return Err(ThoughtError::RenameCollidesWithAlias {
+            old: entity_name.to_string(),
+            new: new_name.to_string(),
+            existing_entity: other.canonical_name,
+        });
     }
 
     let tx = conn.transaction()?;

--- a/src/cli/entity_show.rs
+++ b/src/cli/entity_show.rs
@@ -4,6 +4,7 @@ use crate::services::color_mode::ColorMode;
 use crate::services::entity_styler::EntityStyler;
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_aliases_repository::EntityAliasesRepository;
 use crate::storage::entity_relations_repository::EntityRelationsRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
@@ -30,7 +31,7 @@ pub fn execute(entity_name: &str, db_path: &Path, color_mode: ColorMode) -> Resu
     let conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 
-    let entity = EntitiesRepository::find_by_name(&conn, entity_name)?
+    let entity = EntitiesRepository::resolve(&conn, entity_name)?
         .ok_or_else(|| ThoughtError::EntityNotFound(entity_name.to_string()))?;
 
     let mut styler = EntityStyler::new(color_mode.should_use_colors());
@@ -40,6 +41,12 @@ pub fn execute(entity_name: &str, db_path: &Path, color_mode: ColorMode) -> Resu
     if let Some(description) = &entity.description {
         println!();
         println!("{}", styler.render_content(description));
+    }
+
+    let aliases = EntityAliasesRepository::list_for_entity(&conn, entity.id.unwrap())?;
+    if !aliases.is_empty() {
+        println!();
+        println!("Aliases: {}", aliases.join(", "));
     }
 
     let parents = EntityRelationsRepository::list_parents(&conn, entity.id.unwrap())?;
@@ -151,6 +158,28 @@ mod tests {
         drop(conn);
 
         let result = execute("rust", &db_path, ColorMode::Never);
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_show_with_aliases_succeeds() {
+        use tempfile::TempDir;
+
+        let temp_dir = TempDir::new().unwrap();
+        let db_path = temp_dir.path().join("test.db");
+        let conn = get_connection(&db_path).unwrap();
+        crate::storage::migrations::run_migrations(&conn).unwrap();
+
+        setup_entity(&conn, "rust", None);
+        let entity = EntitiesRepository::find_by_name(&conn, "rust").unwrap().unwrap();
+        EntityAliasesRepository::add_alias(&conn, entity.id.unwrap(), "rustlang").unwrap();
+        drop(conn);
+
+        let result = execute("rust", &db_path, ColorMode::Never);
+        assert!(result.is_ok());
+
+        // Also resolvable by the alias itself.
+        let result = execute("rustlang", &db_path, ColorMode::Never);
         assert!(result.is_ok());
     }
 

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -4,6 +4,7 @@ pub mod config;
 pub mod delete;
 pub mod edit;
 pub mod entities;
+pub mod entity_alias;
 pub mod entity_edit;
 pub mod entity_relate;
 pub mod entity_rename;
@@ -118,5 +119,21 @@ pub enum EntityCommands {
         /// Parent entity name (case-insensitive)
         #[arg(long)]
         parent: String,
+    },
+    /// Register an alternate name for an entity
+    Alias {
+        /// Entity name (case-insensitive; may itself be an existing alias)
+        entity_name: String,
+        /// Alias to register for this entity
+        #[arg(long)]
+        alias: String,
+    },
+    /// Remove a previously-registered alias from an entity
+    Unalias {
+        /// Entity name (case-insensitive; may itself be an existing alias)
+        entity_name: String,
+        /// Alias to remove
+        #[arg(long)]
+        alias: String,
     },
 }

--- a/src/errors/thought_error.rs
+++ b/src/errors/thought_error.rs
@@ -43,6 +43,16 @@ pub enum ThoughtError {
 
     #[error("An entity cannot be its own parent: '{0}'")]
     SelfRelation(String),
+
+    #[error("'{alias}' matches multiple entities ({})", entities.join(", "))]
+    AmbiguousAlias { alias: String, entities: Vec<String> },
+
+    #[error("Cannot rename '{old}' to '{new}': '{new}' is already registered as an alias of '{existing_entity}'")]
+    RenameCollidesWithAlias {
+        old: String,
+        new: String,
+        existing_entity: String,
+    },
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -75,6 +75,12 @@ fn main() {
             EntityCommands::Unrelate { entity_name, parent } => {
                 wetware::cli::entity_relate::execute_unrelate(&entity_name, &parent, &db_path)
             }
+            EntityCommands::Alias { entity_name, alias } => {
+                wetware::cli::entity_alias::execute_alias(&entity_name, &alias, &db_path)
+            }
+            EntityCommands::Unalias { entity_name, alias } => {
+                wetware::cli::entity_alias::execute_unalias(&entity_name, &alias, &db_path)
+            }
         },
     };
 

--- a/src/services/entity_resolution.rs
+++ b/src/services/entity_resolution.rs
@@ -1,0 +1,102 @@
+/// Entity resolution service - resolves extracted entity-reference names to entity IDs,
+/// consulting known aliases before falling back to creating a new literal entity.
+use crate::errors::ThoughtError;
+use crate::models::entity::Entity;
+use crate::storage::entities_repository::EntitiesRepository;
+use rusqlite::Connection;
+
+/// Resolve `name` (as extracted from a `[bracket]` mention in thought/description text)
+/// to an entity ID, creating a new entity if the name doesn't match any existing
+/// canonical name or alias.
+///
+/// - Canonical name or unambiguous alias match: returns that entity's ID, without
+///   creating anything.
+/// - No match anywhere: creates a new entity literally named `name` (existing
+///   behavior, unchanged).
+/// - Ambiguous alias match (the same alias registered to more than one entity):
+///   prints a warning to stderr naming the alias and its candidate entities, and
+///   returns `Ok(None)` - the mention is not linked to any entity, and no new entity
+///   is created. This is a soft, non-fatal condition: it never fails the caller's
+///   overall add/edit operation, mirroring how a failed editor launch is a warning
+///   rather than a hard error elsewhere in the CLI.
+pub fn resolve_or_create_entity(conn: &Connection, name: &str) -> Result<Option<i64>, ThoughtError> {
+    match EntitiesRepository::resolve(conn, name) {
+        Ok(Some(entity)) => Ok(entity.id),
+        Ok(None) => {
+            let entity = Entity::new(name.to_string());
+            Ok(Some(EntitiesRepository::find_or_create(conn, &entity)?))
+        }
+        Err(ThoughtError::AmbiguousAlias { alias, entities }) => {
+            eprintln!(
+                "Warning: '{}' matches multiple entities ({}); skipping link for this mention.",
+                alias,
+                entities.join(", ")
+            );
+            Ok(None)
+        }
+        Err(other) => Err(other),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::connection::get_memory_connection;
+    use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+    use crate::storage::migrations::run_migrations;
+
+    #[test]
+    fn test_resolve_or_create_creates_new_entity_when_unmatched() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let id = resolve_or_create_entity(&conn, "NewEntity").unwrap();
+        assert!(id.is_some());
+
+        let entity = EntitiesRepository::find_by_name(&conn, "newentity").unwrap();
+        assert!(entity.is_some());
+    }
+
+    #[test]
+    fn test_resolve_or_create_resolves_existing_canonical_name() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+
+        let resolved_id = resolve_or_create_entity(&conn, "sarah").unwrap().unwrap();
+        assert_eq!(resolved_id, sarah_id);
+    }
+
+    #[test]
+    fn test_resolve_or_create_resolves_alias_without_creating_new_entity() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah_id, "sar").unwrap();
+
+        let resolved_id = resolve_or_create_entity(&conn, "sar").unwrap().unwrap();
+        assert_eq!(resolved_id, sarah_id);
+
+        // No new literal "sar" entity should have been created.
+        assert!(EntitiesRepository::find_by_name(&conn, "sar").unwrap().is_none());
+    }
+
+    #[test]
+    fn test_resolve_or_create_ambiguous_alias_skips_link() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        let john_id = EntitiesRepository::find_or_create(&conn, &Entity::new("John".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah_id, "boss").unwrap();
+        EntityAliasesRepository::add_alias(&conn, john_id, "boss").unwrap();
+
+        let result = resolve_or_create_entity(&conn, "boss").unwrap();
+        assert!(result.is_none());
+
+        // No new literal "boss" entity should have been created either.
+        assert!(EntitiesRepository::find_by_name(&conn, "boss").unwrap().is_none());
+    }
+}

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod color_mode;
 pub mod description_formatter;
 pub mod entity_parser;
+pub mod entity_resolution;
 pub mod entity_styler;

--- a/src/storage/entities_repository.rs
+++ b/src/storage/entities_repository.rs
@@ -56,6 +56,38 @@ impl EntitiesRepository {
         Ok(entity)
     }
 
+    /// Resolve a user-supplied name to a single entity, consulting canonical names
+    /// first and aliases only as a fallback.
+    ///
+    /// A canonical-name match (case-insensitive) always wins outright, even if some
+    /// other entity also has this name registered as one of its aliases (that other
+    /// entity's alias is simply shadowed). If there is no canonical match, aliases
+    /// are consulted: no match returns `Ok(None)`, exactly one match returns that
+    /// entity, and more than one match (the same alias registered to different
+    /// entities) returns `Err(ThoughtError::AmbiguousAlias)` rather than silently
+    /// picking one.
+    pub fn resolve(conn: &Connection, name: &str) -> Result<Option<Entity>, ThoughtError> {
+        if let Some(entity) = Self::find_by_name(conn, name)? {
+            return Ok(Some(entity));
+        }
+
+        let mut matches =
+            crate::storage::entity_aliases_repository::EntityAliasesRepository::find_entities_by_alias(conn, name)?;
+
+        match matches.len() {
+            0 => Ok(None),
+            1 => Ok(matches.pop()),
+            _ => {
+                let mut names: Vec<String> = matches.into_iter().map(|e| e.canonical_name).collect();
+                names.sort();
+                Err(ThoughtError::AmbiguousAlias {
+                    alias: name.to_string(),
+                    entities: names,
+                })
+            }
+        }
+    }
+
     /// List all entities in alphabetical order
     pub fn list_all(conn: &Connection) -> Result<Vec<Entity>, ThoughtError> {
         let mut stmt =
@@ -148,6 +180,7 @@ impl EntitiesRepository {
 mod tests {
     use super::*;
     use crate::storage::connection::get_memory_connection;
+    use crate::storage::entity_aliases_repository::EntityAliasesRepository;
     use crate::storage::migrations::run_migrations;
 
     #[test]
@@ -413,5 +446,74 @@ mod tests {
         // Original entity untouched
         let found = EntitiesRepository::find_by_name(&conn, "sarah").unwrap();
         assert!(found.is_some());
+    }
+
+    #[test]
+    fn test_resolve_canonical_name_match() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let entity = Entity::new("Sarah".to_string());
+        EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+
+        let resolved = EntitiesRepository::resolve(&conn, "sarah").unwrap().unwrap();
+        assert_eq!(resolved.canonical_name, "Sarah");
+    }
+
+    #[test]
+    fn test_resolve_canonical_wins_over_conflicting_alias() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = Entity::new("Sarah".to_string());
+        EntitiesRepository::find_or_create(&conn, &sarah).unwrap();
+
+        let john_id = EntitiesRepository::find_or_create(&conn, &Entity::new("John".to_string())).unwrap();
+        // "sarah" is registered as an alias of John, but Sarah's own canonical name wins.
+        EntityAliasesRepository::add_alias(&conn, john_id, "sarah").unwrap();
+
+        let resolved = EntitiesRepository::resolve(&conn, "sarah").unwrap().unwrap();
+        assert_eq!(resolved.canonical_name, "Sarah");
+    }
+
+    #[test]
+    fn test_resolve_unambiguous_alias_match() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah_id, "sar").unwrap();
+
+        let resolved = EntitiesRepository::resolve(&conn, "sar").unwrap().unwrap();
+        assert_eq!(resolved.canonical_name, "Sarah");
+    }
+
+    #[test]
+    fn test_resolve_no_match_returns_none() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let resolved = EntitiesRepository::resolve(&conn, "nonexistent").unwrap();
+        assert!(resolved.is_none());
+    }
+
+    #[test]
+    fn test_resolve_ambiguous_alias_errors() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        let john_id = EntitiesRepository::find_or_create(&conn, &Entity::new("John".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah_id, "boss").unwrap();
+        EntityAliasesRepository::add_alias(&conn, john_id, "boss").unwrap();
+
+        let result = EntitiesRepository::resolve(&conn, "boss");
+        match result {
+            Err(ThoughtError::AmbiguousAlias { alias, entities }) => {
+                assert_eq!(alias, "boss");
+                assert_eq!(entities, vec!["John".to_string(), "Sarah".to_string()]);
+            }
+            _ => panic!("Expected AmbiguousAlias error"),
+        }
     }
 }

--- a/src/storage/entity_aliases_repository.rs
+++ b/src/storage/entity_aliases_repository.rs
@@ -19,23 +19,24 @@ impl EntityAliasesRepository {
     /// empty/whitespace-only alias is rejected explicitly here rather than relying on
     /// the table's CHECK constraint alone.
     pub fn add_alias(conn: &Connection, entity_id: i64, alias: &str) -> Result<(), ThoughtError> {
-        if alias.trim().is_empty() {
+        let trimmed = alias.trim();
+        if trimmed.is_empty() {
             return Err(ThoughtError::InvalidInput("Alias cannot be empty".to_string()));
         }
 
         conn.execute(
             "INSERT OR IGNORE INTO entity_aliases (entity_id, alias) VALUES (?1, ?2)",
-            (entity_id, alias),
+            (entity_id, trimmed),
         )?;
         Ok(())
     }
 
     /// Remove `alias` from `entity_id` if present. Safe to call even if no such alias
-    /// is registered (no-op).
+    /// is registered (no-op). Trims `alias` first, matching `add_alias`'s storage form.
     pub fn remove_alias(conn: &Connection, entity_id: i64, alias: &str) -> Result<(), ThoughtError> {
         conn.execute(
             "DELETE FROM entity_aliases WHERE entity_id = ?1 AND alias = ?2",
-            (entity_id, alias),
+            (entity_id, alias.trim()),
         )?;
         Ok(())
     }
@@ -230,5 +231,34 @@ mod tests {
         let sarah = make_entity(&conn, "Sarah");
         let result = EntityAliasesRepository::add_alias(&conn, sarah, "");
         assert!(result.is_err());
+    }
+
+    #[test]
+    fn test_add_alias_trims_surrounding_whitespace() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "  sar  ").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert_eq!(aliases, vec!["sar"]);
+
+        // A later lookup for the untrimmed form still matches, since it's stored trimmed.
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "sar").unwrap();
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_remove_alias_trims_surrounding_whitespace() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+        EntityAliasesRepository::remove_alias(&conn, sarah, "  sar  ").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert!(aliases.is_empty());
     }
 }

--- a/src/storage/entity_aliases_repository.rs
+++ b/src/storage/entity_aliases_repository.rs
@@ -1,0 +1,234 @@
+/// Repository for entity aliases persistence
+use crate::errors::ThoughtError;
+use crate::models::entity::Entity;
+use rusqlite::Connection;
+
+/// Entity aliases repository for database operations
+///
+/// Aliases are unique per entity, not globally: the same alias string may be
+/// registered for more than one entity, so callers resolving an alias to an
+/// entity must handle the possibility of more than one match (see
+/// `find_entities_by_alias` and `EntitiesRepository::resolve`).
+pub struct EntityAliasesRepository;
+
+impl EntityAliasesRepository {
+    /// Register `alias` for `entity_id`. Idempotent - a no-op if the entity already
+    /// has this alias registered.
+    ///
+    /// `INSERT OR IGNORE` also suppresses CHECK constraint failures in SQLite, so an
+    /// empty/whitespace-only alias is rejected explicitly here rather than relying on
+    /// the table's CHECK constraint alone.
+    pub fn add_alias(conn: &Connection, entity_id: i64, alias: &str) -> Result<(), ThoughtError> {
+        if alias.trim().is_empty() {
+            return Err(ThoughtError::InvalidInput("Alias cannot be empty".to_string()));
+        }
+
+        conn.execute(
+            "INSERT OR IGNORE INTO entity_aliases (entity_id, alias) VALUES (?1, ?2)",
+            (entity_id, alias),
+        )?;
+        Ok(())
+    }
+
+    /// Remove `alias` from `entity_id` if present. Safe to call even if no such alias
+    /// is registered (no-op).
+    pub fn remove_alias(conn: &Connection, entity_id: i64, alias: &str) -> Result<(), ThoughtError> {
+        conn.execute(
+            "DELETE FROM entity_aliases WHERE entity_id = ?1 AND alias = ?2",
+            (entity_id, alias),
+        )?;
+        Ok(())
+    }
+
+    /// All aliases registered for `entity_id`, alphabetical.
+    pub fn list_for_entity(conn: &Connection, entity_id: i64) -> Result<Vec<String>, ThoughtError> {
+        let mut stmt = conn.prepare("SELECT alias FROM entity_aliases WHERE entity_id = ?1 ORDER BY alias ASC")?;
+
+        let aliases = stmt
+            .query_map([entity_id], |row| row.get(0))?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(aliases)
+    }
+
+    /// All distinct entities that have `alias` registered (case-insensitive).
+    ///
+    /// Empty vec means the alias isn't registered for any entity. More than one
+    /// entry means the same alias string was registered for multiple entities -
+    /// callers must treat that as ambiguous rather than picking one.
+    pub fn find_entities_by_alias(conn: &Connection, alias: &str) -> Result<Vec<Entity>, ThoughtError> {
+        let mut stmt = conn.prepare(
+            "SELECT e.id, e.name, e.canonical_name, e.description
+             FROM entities e
+             INNER JOIN entity_aliases ea ON ea.entity_id = e.id
+             WHERE ea.alias = ?1
+             ORDER BY e.canonical_name ASC",
+        )?;
+
+        let entities = stmt
+            .query_map([alias], |row| {
+                Ok(Entity {
+                    id: Some(row.get(0)?),
+                    name: row.get(1)?,
+                    canonical_name: row.get(2)?,
+                    description: row.get(3)?,
+                })
+            })?
+            .collect::<Result<Vec<_>, _>>()?;
+
+        Ok(entities)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::storage::connection::get_memory_connection;
+    use crate::storage::entities_repository::EntitiesRepository;
+    use crate::storage::migrations::run_migrations;
+
+    fn make_entity(conn: &Connection, name: &str) -> i64 {
+        let entity = Entity::new(name.to_string());
+        EntitiesRepository::find_or_create(conn, &entity).unwrap()
+    }
+
+    #[test]
+    fn test_add_alias_creates_entry() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert_eq!(aliases, vec!["sar"]);
+    }
+
+    #[test]
+    fn test_add_alias_idempotent() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert_eq!(aliases.len(), 1);
+    }
+
+    #[test]
+    fn test_add_alias_same_alias_two_different_entities() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        let john = make_entity(&conn, "John");
+
+        EntityAliasesRepository::add_alias(&conn, sarah, "boss").unwrap();
+        EntityAliasesRepository::add_alias(&conn, john, "boss").unwrap();
+
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "boss").unwrap();
+        assert_eq!(matches.len(), 2);
+    }
+
+    #[test]
+    fn test_remove_alias_removes_existing() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+        EntityAliasesRepository::remove_alias(&conn, sarah, "sar").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert!(aliases.is_empty());
+    }
+
+    #[test]
+    fn test_remove_alias_nonexistent_is_noop() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        let result = EntityAliasesRepository::remove_alias(&conn, sarah, "sar");
+        assert!(result.is_ok());
+    }
+
+    #[test]
+    fn test_find_entities_by_alias_no_matches() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "nonexistent").unwrap();
+        assert!(matches.is_empty());
+    }
+
+    #[test]
+    fn test_find_entities_by_alias_single_match() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "sar").unwrap();
+        assert_eq!(matches.len(), 1);
+        assert_eq!(matches[0].canonical_name, "Sarah");
+    }
+
+    #[test]
+    fn test_find_entities_by_alias_case_insensitive() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "Sar").unwrap();
+
+        let matches = EntityAliasesRepository::find_entities_by_alias(&conn, "SAR").unwrap();
+        assert_eq!(matches.len(), 1);
+    }
+
+    #[test]
+    fn test_list_for_entity_alphabetical() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "zeta").unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah, "alpha").unwrap();
+
+        let aliases = EntityAliasesRepository::list_for_entity(&conn, sarah).unwrap();
+        assert_eq!(aliases, vec!["alpha", "zeta"]);
+    }
+
+    #[test]
+    fn test_deleting_entity_cascades_alias_removal() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        EntityAliasesRepository::add_alias(&conn, sarah, "sar").unwrap();
+
+        conn.execute("DELETE FROM entities WHERE id = ?1", [sarah]).unwrap();
+
+        let count: i64 = conn
+            .query_row(
+                "SELECT COUNT(*) FROM entity_aliases WHERE entity_id = ?1",
+                [sarah],
+                |row| row.get(0),
+            )
+            .unwrap();
+        assert_eq!(count, 0);
+    }
+
+    #[test]
+    fn test_add_alias_empty_rejected() {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah = make_entity(&conn, "Sarah");
+        let result = EntityAliasesRepository::add_alias(&conn, sarah, "");
+        assert!(result.is_err());
+    }
+}

--- a/src/storage/migrations/entity_aliases_migration.rs
+++ b/src/storage/migrations/entity_aliases_migration.rs
@@ -1,0 +1,73 @@
+/// Database migration for entity aliases (alternate names resolving to a canonical entity)
+/// Creates table: entity_aliases
+use rusqlite::{Connection, Result};
+
+pub fn migrate(conn: &Connection) -> Result<()> {
+    conn.execute(
+        "CREATE TABLE IF NOT EXISTS entity_aliases (
+            entity_id INTEGER NOT NULL,
+            alias TEXT NOT NULL COLLATE NOCASE CHECK(length(trim(alias)) > 0),
+            PRIMARY KEY (entity_id, alias),
+            FOREIGN KEY (entity_id) REFERENCES entities(id) ON DELETE CASCADE
+        )",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_entity_aliases_alias ON entity_aliases(alias)",
+        [],
+    )?;
+
+    conn.execute(
+        "CREATE INDEX IF NOT EXISTS idx_entity_aliases_entity ON entity_aliases(entity_id)",
+        [],
+    )?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_migration_creates_table() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let tables: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='table' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(tables.contains(&"entity_aliases".to_string()));
+    }
+
+    #[test]
+    fn test_migration_creates_indexes() {
+        let conn = Connection::open_in_memory().unwrap();
+        migrate(&conn).unwrap();
+
+        let indexes: Vec<String> = conn
+            .prepare("SELECT name FROM sqlite_master WHERE type='index' ORDER BY name")
+            .unwrap()
+            .query_map([], |row| row.get(0))
+            .unwrap()
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+
+        assert!(indexes.contains(&"idx_entity_aliases_alias".to_string()));
+        assert!(indexes.contains(&"idx_entity_aliases_entity".to_string()));
+    }
+
+    #[test]
+    fn test_migration_idempotent() {
+        let conn = Connection::open_in_memory().unwrap();
+
+        migrate(&conn).unwrap();
+        migrate(&conn).unwrap();
+    }
+}

--- a/src/storage/migrations/mod.rs
+++ b/src/storage/migrations/mod.rs
@@ -1,5 +1,6 @@
 /// Database migrations module
 pub mod add_entity_descriptions_migration;
+pub mod entity_aliases_migration;
 pub mod entity_relations_migration;
 pub mod networked_notes_migration;
 
@@ -16,6 +17,9 @@ pub fn run_migrations(conn: &Connection) -> Result<(), ThoughtError> {
 
     // Run migration 003: entity relations
     entity_relations_migration::migrate(conn)?;
+
+    // Run migration 004: entity aliases
+    entity_aliases_migration::migrate(conn)?;
 
     Ok(())
 }
@@ -42,6 +46,7 @@ mod tests {
         assert!(tables.contains(&"thoughts".to_string()));
         assert!(tables.contains(&"entities".to_string()));
         assert!(tables.contains(&"thought_entities".to_string()));
+        assert!(tables.contains(&"entity_aliases".to_string()));
 
         // Verify description column exists in entities table
         let description_col_exists: bool = conn

--- a/src/storage/mod.rs
+++ b/src/storage/mod.rs
@@ -1,6 +1,7 @@
 pub mod connection;
 pub mod data_dir;
 pub mod entities_repository;
+pub mod entity_aliases_repository;
 pub mod entity_relations_repository;
 pub mod migrations;
 pub mod thoughts_repository;
@@ -8,6 +9,7 @@ pub mod thoughts_repository;
 pub use connection::{get_connection, get_memory_connection};
 pub use data_dir::{default_db_path_in, ensure_data_dir, resolve_data_dir};
 pub use entities_repository::EntitiesRepository;
+pub use entity_aliases_repository::EntityAliasesRepository;
 pub use entity_relations_repository::EntityRelationsRepository;
 pub use migrations::run_migrations;
 pub use thoughts_repository::ThoughtsRepository;

--- a/src/storage/thoughts_repository.rs
+++ b/src/storage/thoughts_repository.rs
@@ -101,14 +101,18 @@ impl ThoughtsRepository {
         Ok(())
     }
 
-    /// List thoughts filtered by entity name (case-insensitive), including thoughts
-    /// linked to any entity transitively reachable via child relations (descendants).
+    /// List thoughts filtered by entity name or alias (case-insensitive), including
+    /// thoughts linked to any entity transitively reachable via child relations
+    /// (descendants). An unknown name/alias returns an empty list; an alias registered
+    /// to more than one entity returns `ThoughtError::AmbiguousAlias`.
     pub fn list_by_entity(conn: &Connection, entity_name: &str) -> Result<Vec<Thought>, ThoughtError> {
-        let lowercase_name = entity_name.to_lowercase();
+        let Some(entity) = crate::storage::entities_repository::EntitiesRepository::resolve(conn, entity_name)? else {
+            return Ok(Vec::new());
+        };
 
         let mut stmt = conn.prepare(
             "WITH RECURSIVE reachable(id) AS (
-                 SELECT id FROM entities WHERE name = ?1
+                 SELECT ?1
                  UNION
                  SELECT er.child_id FROM entity_relations er JOIN reachable r ON er.parent_id = r.id
              )
@@ -120,7 +124,7 @@ impl ThoughtsRepository {
         )?;
 
         let thoughts = stmt
-            .query_map([lowercase_name], |row| {
+            .query_map([entity.id.unwrap()], |row| {
                 let created_at_str: String = row.get(2)?;
                 let created_at = DateTime::parse_from_rfc3339(&created_at_str)
                     .map_err(|e| {
@@ -139,19 +143,22 @@ impl ThoughtsRepository {
         Ok(thoughts)
     }
 
-    /// List the most recent thoughts linked to an entity (case-insensitive), newest first,
-    /// including thoughts linked to any entity transitively reachable via child relations
-    /// (descendants).
+    /// List the most recent thoughts linked to an entity name or alias (case-insensitive),
+    /// newest first, including thoughts linked to any entity transitively reachable via
+    /// child relations (descendants). An unknown name/alias returns an empty list; an
+    /// alias registered to more than one entity returns `ThoughtError::AmbiguousAlias`.
     pub fn list_latest_by_entity(
         conn: &Connection,
         entity_name: &str,
         limit: usize,
     ) -> Result<Vec<Thought>, ThoughtError> {
-        let lowercase_name = entity_name.to_lowercase();
+        let Some(entity) = crate::storage::entities_repository::EntitiesRepository::resolve(conn, entity_name)? else {
+            return Ok(Vec::new());
+        };
 
         let mut stmt = conn.prepare(
             "WITH RECURSIVE reachable(id) AS (
-                 SELECT id FROM entities WHERE name = ?1
+                 SELECT ?1
                  UNION
                  SELECT er.child_id FROM entity_relations er JOIN reachable r ON er.parent_id = r.id
              )
@@ -164,7 +171,7 @@ impl ThoughtsRepository {
         )?;
 
         let thoughts = stmt
-            .query_map((lowercase_name, limit as i64), |row| {
+            .query_map((entity.id.unwrap(), limit as i64), |row| {
                 let created_at_str: String = row.get(2)?;
                 let created_at = DateTime::parse_from_rfc3339(&created_at_str)
                     .map_err(|e| {
@@ -523,6 +530,48 @@ mod tests {
 
         let thoughts = ThoughtsRepository::list_by_entity(&conn, "nonexistent").unwrap();
         assert!(thoughts.is_empty());
+    }
+
+    #[test]
+    fn test_list_by_entity_resolves_alias_same_as_canonical_name() {
+        use crate::models::entity::Entity;
+        use crate::storage::entities_repository::EntitiesRepository;
+        use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let entity = Entity::new("Rust".to_string());
+        let entity_id = EntitiesRepository::find_or_create(&conn, &entity).unwrap();
+        EntityAliasesRepository::add_alias(&conn, entity_id, "rustlang").unwrap();
+
+        let thought = Thought::new("Learning [Rust]".to_string()).unwrap();
+        let thought_id = ThoughtsRepository::save(&conn, &thought).unwrap();
+        EntitiesRepository::link_to_thought(&conn, entity_id, thought_id).unwrap();
+
+        let by_canonical = ThoughtsRepository::list_by_entity(&conn, "rust").unwrap();
+        let by_alias = ThoughtsRepository::list_by_entity(&conn, "rustlang").unwrap();
+        assert_eq!(by_canonical.len(), 1);
+        assert_eq!(by_alias.len(), 1);
+        assert_eq!(by_canonical[0].id, by_alias[0].id);
+    }
+
+    #[test]
+    fn test_list_by_entity_ambiguous_alias_errors() {
+        use crate::models::entity::Entity;
+        use crate::storage::entities_repository::EntitiesRepository;
+        use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let sarah_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        let john_id = EntitiesRepository::find_or_create(&conn, &Entity::new("John".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah_id, "boss").unwrap();
+        EntityAliasesRepository::add_alias(&conn, john_id, "boss").unwrap();
+
+        let result = ThoughtsRepository::list_by_entity(&conn, "boss");
+        assert!(matches!(result, Err(ThoughtError::AmbiguousAlias { .. })));
     }
 
     #[test]

--- a/tests/contract/mod.rs
+++ b/tests/contract/mod.rs
@@ -2,6 +2,7 @@
 mod test_add_command;
 mod test_edit_command;
 mod test_entities_command;
+mod test_entity_alias_command;
 mod test_entity_edit_command;
 mod test_entity_relate_command;
 mod test_entity_rename_command;

--- a/tests/contract/test_entity_alias_command.rs
+++ b/tests/contract/test_entity_alias_command.rs
@@ -1,0 +1,126 @@
+/// Contract tests for `wet entity alias` / `wet entity unalias` commands
+use crate::test_helpers::{run_wet_command, setup_temp_db};
+
+#[test]
+fn test_entity_alias_happy_path_filters_thoughts() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("Alias 'sar' added for entity 'Sarah'"),
+        "Should show success message. Got: {}",
+        result.stdout
+    );
+
+    let thoughts_result = run_wet_command(&["thoughts", "--on", "sar"], Some(&temp_db));
+    assert!(
+        thoughts_result.stdout.contains("Meeting with"),
+        "Filtering by alias 'sar' should return the same thoughts as 'sarah'. Got: {}",
+        thoughts_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_alias_missing_entity_errors() {
+    let temp_db = setup_temp_db();
+
+    let result = run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("Entity 'sarah' not found") || result.stdout.contains("Entity 'sarah' not found"),
+        "Should show entity not found error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_alias_same_alias_two_entities_both_succeed() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "About [Sarah] and [John]"], Some(&temp_db));
+
+    let result1 = run_wet_command(&["entity", "alias", "sarah", "--alias", "boss"], Some(&temp_db));
+    let result2 = run_wet_command(&["entity", "alias", "john", "--alias", "boss"], Some(&temp_db));
+
+    assert_eq!(result1.status, 0, "First alias registration should succeed");
+    assert_eq!(
+        result2.status, 0,
+        "Second alias registration (same alias, different entity) should succeed"
+    );
+
+    let filter_result = run_wet_command(&["thoughts", "--on", "boss"], Some(&temp_db));
+    assert_ne!(filter_result.status, 0, "Filtering by an ambiguous alias should fail");
+    assert!(
+        filter_result.stderr.contains("multiple entities") || filter_result.stdout.contains("multiple entities"),
+        "Should show ambiguous-alias error. stderr: {}, stdout: {}",
+        filter_result.stderr,
+        filter_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_unalias_removes_alias() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "unalias", "sarah", "--alias", "sar"], Some(&temp_db));
+    assert_eq!(result.status, 0, "Command should succeed");
+    assert!(
+        result.stdout.contains("Alias 'sar' removed from entity 'Sarah'"),
+        "Should show success message. Got: {}",
+        result.stdout
+    );
+
+    let thoughts_result = run_wet_command(&["thoughts", "--on", "sar"], Some(&temp_db));
+    assert!(
+        !thoughts_result.stdout.contains("Meeting with"),
+        "Filtering by the removed alias should no longer match the thought. Got: {}",
+        thoughts_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_alias_bracket_mention_resolves_to_aliased_entity() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    let add_result = run_wet_command(&["add", "Talked to [sar] again"], Some(&temp_db));
+    assert_eq!(add_result.status, 0, "Add should succeed");
+
+    let entities_result = run_wet_command(&["entities"], Some(&temp_db));
+    let sar_count = entities_result
+        .stdout
+        .lines()
+        .filter(|line| line.to_lowercase().contains("sar"))
+        .count();
+    assert_eq!(
+        sar_count, 1,
+        "No new literal 'sar' entity should be created; only 'Sarah' should mention 'sar'. Got: {}",
+        entities_result.stdout
+    );
+}
+
+#[test]
+fn test_entity_show_lists_aliases() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "show", "sarah"], Some(&temp_db));
+    assert!(
+        result.stdout.contains("Aliases: sar"),
+        "Should list 'sar' as an alias. Got: {}",
+        result.stdout
+    );
+}

--- a/tests/contract/test_entity_rename_command.rs
+++ b/tests/contract/test_entity_rename_command.rs
@@ -60,6 +60,50 @@ fn test_entity_rename_collision_with_different_entity() {
 }
 
 #[test]
+fn test_entity_rename_rejects_collision_with_other_entitys_alias() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah] and [John]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "john", "--alias", "boss"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "rename", "sarah", "boss"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "Command should fail");
+    assert!(
+        result.stderr.contains("already registered as an alias")
+            || result.stdout.contains("already registered as an alias"),
+        "Should show alias-collision error. stderr: {}, stdout: {}",
+        result.stderr,
+        result.stdout
+    );
+}
+
+#[test]
+fn test_entity_rename_to_own_alias_succeeds() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "sarah", "--alias", "boss"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "rename", "sarah", "boss"], Some(&temp_db));
+    assert_eq!(result.status, 0, "Renaming to the entity's own alias should succeed");
+}
+
+#[test]
+fn test_entity_rename_by_alias_lookup() {
+    let temp_db = setup_temp_db();
+
+    run_wet_command(&["add", "Meeting with [Sarah]"], Some(&temp_db));
+    run_wet_command(&["entity", "alias", "sarah", "--alias", "sar"], Some(&temp_db));
+
+    let result = run_wet_command(&["entity", "rename", "sar", "Sarah Smith"], Some(&temp_db));
+    assert_eq!(
+        result.status, 0,
+        "Should be able to rename an entity by referencing one of its aliases"
+    );
+}
+
+#[test]
 fn test_entity_rename_nonexistent_entity() {
     let temp_db = setup_temp_db();
 

--- a/tests/integration/test_entity_references.rs
+++ b/tests/integration/test_entity_references.rs
@@ -249,3 +249,61 @@ fn test_list_all_entities_alphabetical() -> Result<(), ThoughtError> {
 
     Ok(())
 }
+
+#[test]
+fn test_add_command_bracket_mention_resolves_to_aliased_entity() {
+    use wetware::storage::entity_aliases_repository::EntityAliasesRepository;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
+    run_migrations(&conn).unwrap();
+    let sarah_id =
+        EntitiesRepository::find_or_create(&conn, &wetware::models::entity::Entity::new("Sarah".to_string())).unwrap();
+    EntityAliasesRepository::add_alias(&conn, sarah_id, "sar").unwrap();
+    drop(conn);
+
+    let result = add::execute("Talked to [sar] again".to_string(), None, &db_path);
+    assert!(result.is_ok());
+
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
+    let entities = EntitiesRepository::list_all(&conn).unwrap();
+    // No new literal "sar" entity should have been created - only "Sarah" exists.
+    assert_eq!(entities.len(), 1);
+    assert_eq!(entities[0].canonical_name, "Sarah");
+
+    let thoughts = ThoughtsRepository::list_by_entity(&conn, "sarah").unwrap();
+    assert_eq!(thoughts.len(), 1);
+}
+
+#[test]
+fn test_add_command_ambiguous_alias_mention_skips_link_but_saves_thought() {
+    use wetware::storage::entity_aliases_repository::EntityAliasesRepository;
+
+    let temp_dir = TempDir::new().unwrap();
+    let db_path = temp_dir.path().join("test.db");
+
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
+    run_migrations(&conn).unwrap();
+    let sarah_id =
+        EntitiesRepository::find_or_create(&conn, &wetware::models::entity::Entity::new("Sarah".to_string())).unwrap();
+    let john_id =
+        EntitiesRepository::find_or_create(&conn, &wetware::models::entity::Entity::new("John".to_string())).unwrap();
+    EntityAliasesRepository::add_alias(&conn, sarah_id, "boss").unwrap();
+    EntityAliasesRepository::add_alias(&conn, john_id, "boss").unwrap();
+    drop(conn);
+
+    // The whole add still succeeds even though "boss" is ambiguous.
+    let result = add::execute("Mentioned [boss] today".to_string(), None, &db_path);
+    assert!(result.is_ok());
+
+    let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
+    // No new literal "boss" entity created.
+    let entities = EntitiesRepository::list_all(&conn).unwrap();
+    assert_eq!(entities.len(), 2);
+
+    // Neither Sarah nor John got linked to the new thought.
+    assert!(ThoughtsRepository::list_by_entity(&conn, "sarah").unwrap().is_empty());
+    assert!(ThoughtsRepository::list_by_entity(&conn, "john").unwrap().is_empty());
+}


### PR DESCRIPTION
## Summary

- Entities can now register persisted "known aliases" (`wet entity alias <name> --alias <x>` / `wet entity unalias <name> --alias <x>`) — alternate names that resolve to the same entity anywhere a name is looked up: `--on` filtering, `entity show`/`edit`/`rename`/`relate`/`unrelate`, and `[bracket]` mentions in thought/description text.
- Aliases are unique **per entity, not globally** — the same alias string can be registered to more than one entity. Resolving an alias that matches more than one entity is a first-class `AmbiguousAlias` error on direct lookups, and a warn-and-skip (not a hard failure) when hit via a `[bracket]` mention during `add`/`edit`.
- `wet entity rename` gains a guard against renaming into a name already registered as a *different* entity's alias (which would otherwise silently shadow it).
- `wet entity show` gains an `Aliases: ...` line.
- New ADR [`0013-entity-aliases.md`](docs/architecture/decisions/0013-entity-aliases.md) and flow doc [`entity-alias-resolution.md`](docs/flows/entity-alias-resolution.md), plus updates to `storage.md`/`models.md`/`services.md`/`cli.md`/`entity-rename.md`/glossary.

## Test plan

- [x] `cargo nextest run` — 463 passed
- [x] `cargo clippy` / `cargo fmt` clean on all touched files
- [x] Manual smoke test: alias registration/filtering, ambiguous-alias error and warn-skip paths, rename-collision guard, `entity show` aliases line

🤖 Generated with [Claude Code](https://claude.com/claude-code)