### PR TITLE
feat(cli): interactive thought composer (wet add -i)

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,6 +56,7 @@ Domain model must not depend on CLI or persistence. Persistence is behind reposi
 - thiserror 2.0 (error types), owo-colors 4 (terminal styling), terminal_size 0.4 (TTY detection)
 - tempfile 3.27 (editor temp files), dirs 6.0 (XDG data directory), serde 1 + toml 0.8 (config)
 - ratatui 0.30 + crossterm (TUI framework), tui-input 0.15 (text input), nucleo-matcher 0.3 (fuzzy search)
+- unicode-width 0.2 (display-width word wrapping in the composer; already in the tree via ratatui)
 
 ## Data Directory
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2114,6 +2114,7 @@ dependencies = [
  "thiserror 2.0.19",
  "toml",
  "tui-input",
+ "unicode-width",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,6 +24,9 @@ toml = "1.1"
 ratatui = "0.30"
 tui-input = "0.15"
 nucleo-matcher = "0.3"
+# Already in the tree via ratatui; direct so the composer can wrap by display
+# width rather than character count.
+unicode-width = "0.2"
 
 [dev-dependencies]
 tempfile = "3.27"

--- a/README.md
+++ b/README.md
@@ -4,9 +4,10 @@ A simple CLI tool for managing networked notes with entity references.
 
 ## Features
 
-- Add quick notes via command line
+- Add quick notes via command line, or interactively with entity completion and syntax help
 - Edit existing thoughts: correct content, update date, or both
 - Reference entities using `[entity-name]` or `[alias](entity-name)` syntax
+- Relative dates everywhere a date is accepted: `today`, `yesterday`, `-3d`, `mon`
 - Filter notes by entity
 - Case-insensitive entity matching with first-occurrence capitalization
 - Add multi-paragraph descriptions to entities
@@ -29,6 +30,42 @@ The binary will be available at `target/release/wetware`.
 ```bash
 wet add "Meeting with [Sarah] about [project-alpha]"
 ```
+
+Backdate it with `--date`, which accepts `YYYY-MM-DD` as well as `today`, `yesterday`, `tomorrow`,
+offsets like `-3d` / `-2w` / `-1m`, and weekday names:
+
+```bash
+wet add "Retro notes on [project-alpha]" --date yesterday
+```
+
+### Add a note interactively
+
+Run `wet add` with no text (or `wet add -i`) to open the composer:
+
+```bash
+wet add -i
+```
+
+It gives you a date field that shows what your input resolves to as you type, and a thought field where
+typing `[` opens a fuzzy search over the entities you already have — including their aliases. Pick one
+and it inserts `[Name]`, or `[alias](Name)` if you chose an alias.
+
+To link some wording of your own to an entity, type the wording, then `](` — the search reopens on the
+link target and fills in just the entity name:
+
+```
+met [my boss](      →  search reopens  →  met [my boss](Alice)
+```
+
+A live preview shows how the thought will read, and flags any mention that would create a brand-new
+entity, so typos don't quietly become duplicates. You can still type any name you like; nothing forces
+you to pick from the list.
+
+`Alt+←` and `Alt+→` shift the date a day earlier or later without leaving the thought field, so
+backdating something to yesterday doesn't cost a trip to the date field and back.
+
+`Tab` switches fields (and accepts a completion when the popup is open), `Enter` saves and clears the
+thought field so you can keep going, and `Esc` exits.
 
 ### Edit an existing thought
 

--- a/docs/architecture/README.md
+++ b/docs/architecture/README.md
@@ -113,6 +113,7 @@ order they were made:
 | [0012](decisions/0012-entity-relations.md) | Directed entity parent/child relations (DAG) with recursive-CTE reachability |
 | [0013](decisions/0013-entity-aliases.md) | Persisted per-entity alias registry with canonical-name precedence |
 | [0014](decisions/0014-entity-merge.md) | `wet entity merge`, wording-preserving reference redirect, both histories kept |
+| [0015](decisions/0015-interactive-thought-composer.md) | `wet add -i` composer with entity whisperer, shared relative-date parsing |
 
 Only ADRs with `status: Accepted` reflect current guidance — see each ADR's frontmatter.
 

--- a/docs/architecture/decisions/0015-interactive-thought-composer.md
+++ b/docs/architecture/decisions/0015-interactive-thought-composer.md
@@ -1,0 +1,121 @@
+---
+status: Accepted
+date: "2026-08-09"
+---
+
+# Interactive thought composer with entity whisperer and relative dates
+
+## Context
+
+`wet add "content" --date YYYY-MM-DD` was the only way to record a thought, and it gave no help with
+the two things that are hardest to get right at the moment of writing:
+
+- **Entity mention syntax.** `[Entity]` and `[alias](Entity)` are documented in `--help` and in
+  [`../../systems/services.md`](../../systems/services.md), but nothing at the point of entry shows
+  which entities already exist. Because `entity_resolution::resolve_or_create_entity` creates an entity
+  on any miss, a typo silently produces a near-duplicate that must later be cleaned up with
+  `wet entity merge` (see [`0014-entity-merge.md`](0014-entity-merge.md)).
+- **Dates.** Only strict `YYYY-MM-DD` was accepted, and the parsing was duplicated inline in
+  `cli/add.rs` and `cli/edit.rs`. Backdating a thought by a couple of days meant looking up a calendar.
+
+Thoughts are entered often and in small quantities, so the friction here compounds.
+
+## Decision
+
+Add an interactive composer, reached via `wet add -i` or bare `wet add` with no content argument,
+built as `src/tui/compose/` alongside the existing browser TUI and following the same Elm-style
+state/input/ui split established in [`0006-tui-viewer.md`](0006-tui-viewer.md).
+
+The composer presents a date field, a content field, a live preview, and a persistent syntax help
+footer. Typing `[` in the content field opens a fuzzy "whisperer" popup over every known entity
+canonical name **and** alias; accepting a canonical name inserts `[Name]`, accepting an alias inserts
+`[alias](Name)`.
+
+The whisperer has a second trigger, for the case the first one cannot serve. `entity_parser`'s
+`[wording](target)` syntax is free-form per-occurrence display text (see
+[`0004-entity-reference-aliases.md`](0004-entity-reference-aliases.md)), so wording written by hand —
+`met [my boss](…` — will never fuzzy-match a candidate. Typing `(` **directly after a `]`** therefore
+opens the popup on the *target* slot instead, where accepting writes only `(Canonical)` and leaves the
+wording alone. Without this, the one place a typo silently creates an unwanted entity is precisely the
+place the whisperer was not firing. `(` elsewhere is ordinary prose and does not trigger it.
+
+Text that matches nothing is left alone, so new entities can still be created by
+typing freely — the preview marks those mentions `+new` so the choice is deliberate rather than
+accidental. Saving clears the content but keeps the date, so a run of thoughts can be entered in one
+sitting.
+
+Two supporting decisions fall out of this:
+
+- **Date parsing becomes a shared service**, `services::date_parser`, accepting `YYYY-MM-DD`,
+  `today`/`yesterday`/`tomorrow`, signed offsets (`-3d`, `-2w`, `-1m`), and weekday names. It backs the
+  composer's date field *and* `wet add --date` / `wet edit --date`, so the CLI and the composer can never
+  drift apart on what a date looks like.
+- **Thought creation becomes a shared service**, `services::thought_writer::create_thought`, wrapping
+  the save-and-link sequence in a transaction. `wet add` previously did this non-transactionally, unlike
+  `wet edit`; sharing the path with the composer fixed that asymmetry as a side effect.
+
+## Consequences
+
+- The syntax is discoverable at the moment it is needed, and near-duplicate entities from typos become
+  visible before they are written rather than after.
+- `Alt-Left`/`Alt-Right` shift the date by a day from either field. A separate date field is the right
+  home for the *value*, but tabbing over and back to say "actually, yesterday" costs more than the edit
+  is worth, so the common adjustment gets a binding that skips the round-trip entirely. The cost is one
+  more thing to know about; the help footer carries it, and the two-field model is unchanged.
+- Relative dates now work everywhere a date is accepted, not just in the composer. `--date` gained
+  `allow_hyphen_values` so `--date -3d` parses as a value rather than an unknown flag; the cost is that
+  `--date --editor` would consume `--editor` as a (rejected) date string.
+- `wet add`'s `CONTENT` argument became optional. This is backward compatible for every existing
+  invocation, but it means `wet add` with a typo'd flag now opens the composer instead of erroring.
+- The composer needs a TTY. Without one it returns a plain `InvalidInput` explaining that content should
+  be passed as an argument, rather than attempting to start ratatui against a pipe.
+- Content is a single *logical* line — `tui_input::Input` holds no newlines, and thoughts are brief
+  snippets by design, so multi-paragraph entry remains the job of `wet edit --editor` (see
+  [`0005-edit-thoughts.md`](0005-edit-thoughts.md)). It is nonetheless **word-wrapped for display** over
+  as many rows as it needs: a single rendered line silently hid everything past the right edge, which is
+  unusable for anything but the shortest note. Wrapping lives in `tui/compose/wrap.rs` rather than
+  leaning on `Paragraph::wrap`, because the cursor has to be placed at the wrapped position and deriving
+  it from a second, independent wrap implementation would eventually disagree with what was drawn.
+  `unicode-width` became a direct dependency for this; it was already compiled in the tree via ratatui,
+  so it costs no additional build.
+- The composer holds one database connection open for its whole session, unlike the browser `App`, which
+  reopens one per mutation. It writes repeatedly, so a connection per keystroke-batch would be wasteful.
+- Two helpers were lifted out of the browser TUI to be shared: `tui::fuzzy` (previously inline in the
+  entity picker) and `tui::ui::styled_content_line`. The latter's truncation was byte-sliced and would
+  panic on a multibyte character at the boundary — harmless in the browser, where content comes from the
+  database, but the composer feeds it live keystrokes, so it was made char-boundary safe.
+
+## Alternatives considered
+
+- **An `a` key inside `wet tui`.** Rejected as the primary entry point: `wet tui` loads all thoughts,
+  entities, and relations upfront and is built for browsing, so adding a write mode would entangle two
+  concerns and require refreshing the loaded data set mid-session. A separate composer keeps both simple.
+  Wiring one into `wet tui` later remains possible.
+- **A date prefix inside the content line** (`2026-08-01 met with [Alice]`, stripped on save). Rejected as
+  ambiguous — a thought may legitimately begin with a date — and undiscoverable.
+- **Requiring the whisperer's selection**, i.e. only allowing existing entities. Rejected: creating an
+  entity by simply mentioning it is the core of the bracket-markup design
+  (see [`0001-networked-notes-schema.md`](0001-networked-notes-schema.md)); the `+new` marker gives
+  visibility without taking that away.
+- **An explicit completion key** (Ctrl-E) instead of triggering on `[`. Rejected as a worse default: `[`
+  is already the character you type when you mean "an entity goes here", so it carries the intent
+  unambiguously. Esc dismisses the popup for anyone who wants a literal bracket.
+- **A date-parsing crate** such as `chrono-english` or `dateparser`. Rejected per the project's
+  preference for lightweight, focused dependencies: the handful of forms wanted here is a small amount of
+  code over `chrono`, which is already a dependency.
+
+## Related code
+
+- [`src/tui/compose/`](../../../src/tui/compose/) — the composer
+- [`src/services/date_parser.rs`](../../../src/services/date_parser.rs)
+- [`src/services/thought_writer.rs`](../../../src/services/thought_writer.rs)
+- [`src/tui/fuzzy.rs`](../../../src/tui/fuzzy.rs)
+- [`src/cli/add.rs`](../../../src/cli/add.rs)
+
+## Related docs
+
+- [`../../systems/tui.md`](../../systems/tui.md), [`../../systems/cli.md`](../../systems/cli.md),
+  [`../../systems/services.md`](../../systems/services.md)
+- [`../../flows/add-thought-interactive.md`](../../flows/add-thought-interactive.md)
+- [`0006-tui-viewer.md`](0006-tui-viewer.md), [`0004-entity-reference-aliases.md`](0004-entity-reference-aliases.md),
+  [`0013-entity-aliases.md`](0013-entity-aliases.md)

--- a/docs/flows/add-thought-interactive.md
+++ b/docs/flows/add-thought-interactive.md
@@ -32,7 +32,10 @@ flags mentions which would create a brand-new entity.
 5. Each keystroke goes to `compose::input::handle_key_event`, which picks one of two key maps depending
    on whether the whisperer popup is open.
 6. **Whisperer closed**: `Tab`/`Shift-Tab` switches focus between the date and content fields, `Enter`
-   saves, `Esc` and `Ctrl-C` quit, everything else goes to the focused `tui_input::Input`.
+   saves, `Ctrl-C` quits, everything else goes to the focused `tui_input::Input`. `Esc` quits too, but
+   only straight away when the thought field is empty: with unsaved text it arms a confirmation
+   (`pending_quit`) and says so in the status line, and any edit disarms it again. Discarding written
+   text is the one destructive dismissal in the composer, so it is the one that asks.
    `Alt-Left`/`Alt-Right` shift the date a day earlier or later from wherever the focus is, so a
    one-day correction never costs a trip to the date field and back; the field is rewritten as an
    absolute `YYYY-MM-DD` so repeated presses compose.
@@ -52,13 +55,20 @@ flags mentions which would create a brand-new entity.
    A space is appended so typing continues without reaching for one; it is skipped when the following
    text already begins with whitespace or with punctuation that should hug the reference
    (`[Alice].`, `[Alice]'s`). `ComposeApp::save` trims, so that convenience space never reaches storage.
+
+   Entities whose canonical name contains a parenthesis are not offered in the target slot at all:
+   `ENTITY_PATTERN`'s target group cannot span a nested paren, so `[my thing](Wetware (project))` would
+   degrade to the traditional form and silently create an entity named after the display text. They stay
+   reachable through the display slot, which tolerates parens.
 10. The popup closes on its own when the reference is finished or abandoned: the slot's own closing
     character in the query (`]` for the display slot, `)` for the target slot), the cursor moving back to
     or past the opening bracket, or that bracket being deleted.
 11. With no matches, the popup says so rather than blocking: `Enter` falls through to a save, so a
     brand-new entity name can be typed freely.
 12. Every frame re-renders the preview from the raw content, resolving markup to display text and
-    appending a `+new:` marker listing mentions absent from `known_lower`. Both the content field and
+    showing a `+new:` marker for mentions absent from `known_lower`. The marker occupies its own
+    reserved row rather than trailing the text, so wrapping can never drop it — appended inline it
+    disappeared exactly on the long thoughts where a typo is most likely. Both the content field and
     the preview word-wrap over as many rows as they need (`tui/compose/wrap.rs`), growing up to a cap
     and then scrolling to keep the cursor's row visible — text past the right edge is wrapped, never
     hidden.
@@ -67,8 +77,10 @@ flags mentions which would create a brand-new entity.
 14. On success the content field is cleared, the date field is kept, the save counter increments, and
     the candidates are reloaded so entities the save just created are immediately completable. The
     composer stays open.
-15. `Esc` sets `should_quit`, the loop ends, `cli/add.rs` calls `ratatui::restore()` and prints how many
-    thoughts were added.
+15. `Esc` (confirmed, if there was unsaved text) sets `should_quit`, the loop ends, and `cli/add.rs`
+    calls `ratatui::restore()` and prints how many thoughts were added. The count is printed *before*
+    any `run` error is propagated: those saves are already committed, and a terminal failure must not
+    leave the user unsure whether their work landed.
 
 ## Data and state changes
 
@@ -92,9 +104,13 @@ composer is ready for the next thought. On exit, `wet` prints the session total 
   type. `Enter` refuses to save and repeats the message in the status line; the content is untouched.
 - **Empty or oversized content** — `Thought::new`'s validation error lands in the status line and the
   content is preserved so it can be corrected.
-- **Ambiguous alias** — as everywhere else, `entity_resolution` skips the link with a stderr warning
-  rather than failing the save (see [`entity-alias-resolution.md`](entity-alias-resolution.md)). Because
-  the composer owns the alternate screen, that warning is not visible until the composer exits.
+- **Ambiguous alias** — the mention is skipped rather than failing the save (see
+  [`entity-alias-resolution.md`](entity-alias-resolution.md)), and the composer reports it in its own
+  status line: `Saved thought #N, but 'sar' matches multiple entities (…)`. The composer calls
+  `entity_resolution::resolve_entity`, which *returns* the ambiguity, not `resolve_or_create_entity`,
+  which prints it. Printing would be wrong here: stderr and the alternate screen are the same tty, so
+  the warning lands mid-frame with no carriage return, and because ratatui redraws only diffs the smear
+  survives for the rest of the session.
 - **Storage failure mid-save** — the transaction rolls back, so no partially-linked thought survives;
   the error appears in the status line and the composer stays open.
 

--- a/docs/flows/add-thought-interactive.md
+++ b/docs/flows/add-thought-interactive.md
@@ -1,0 +1,155 @@
+# Add a Thought Interactively
+
+## Purpose
+
+Record a new thought through a guided full-screen composer that teaches the entry syntax as you type:
+relative dates resolved live, fuzzy completion over existing entities and aliases, and a preview that
+flags mentions which would create a brand-new entity.
+
+## Trigger
+
+`wet add -i`, or `wet add` with no `CONTENT` argument. An optional `--date` pre-fills the date field.
+
+## Participants
+
+- `cli/add.rs` — dispatches between the direct and interactive paths, owns terminal setup/teardown
+- `tui/compose/` — `ComposeApp` state, key handling, rendering
+- `tui/fuzzy.rs` — candidate scoring, shared with the browser TUI's entity picker
+- `services::date_parser` — resolves the date field
+- `services::thought_writer` — persists the thought and links its mentions
+- `storage::{entities_repository, entity_aliases_repository}` — the completion candidates
+
+## Step-by-step flow
+
+1. `cli/add.rs::execute` sees no `CONTENT` and calls `compose_interactively`.
+2. If stdin or stdout is not a terminal, it returns an `InvalidInput` error naming the non-interactive
+   alternative, and stops — ratatui is never started.
+3. A connection is opened and migrated, then `ComposeApp::new` loads the completion candidates:
+   every entity's canonical name plus each of its registered aliases. Aliases carry the canonical name
+   they point at. The lowercased set of all of them becomes `known_lower`.
+4. `ratatui::init()` takes over the terminal and `ComposeApp::run` enters a blocking draw/`event::read`
+   loop, the same shape as the browser TUI's `App::run`.
+5. Each keystroke goes to `compose::input::handle_key_event`, which picks one of two key maps depending
+   on whether the whisperer popup is open.
+6. **Whisperer closed**: `Tab`/`Shift-Tab` switches focus between the date and content fields, `Enter`
+   saves, `Esc` and `Ctrl-C` quit, everything else goes to the focused `tui_input::Input`.
+   `Alt-Left`/`Alt-Right` shift the date a day earlier or later from wherever the focus is, so a
+   one-day correction never costs a trip to the date field and back; the field is rewritten as an
+   absolute `YYYY-MM-DD` so repeated presses compose.
+7. **Typing `[` in the content field** opens the whisperer on the reference's display slot, anchored at
+   that bracket's character index. The query is the text between the bracket and the cursor; it is scored
+   against every candidate label by `fuzzy::match_indices`. An empty query offers everything.
+8. **Typing `(` straight after a `]`** opens the whisperer on the *target* slot instead, titled
+   `Entities → links to`. This covers the case where the display wording was written by hand
+   (`met [my boss](…`) and so will never match a candidate; the target still gets completion, which is
+   where a typo would otherwise create an unwanted entity. A `(` anywhere else is ordinary prose and does
+   not trigger the popup.
+9. **Whisperer open**: arrows move the highlight; `Tab`/`Enter` accepts; `Esc` dismisses the popup while
+   keeping the typed text. Accepting in the display slot replaces the partial `[query` with
+   `[Canonical]`, or `[alias](Canonical)` when a registered alias was chosen. Accepting in the target
+   slot replaces `(query` with `(Canonical)` — a registered alias contributes only the entity it points
+   at, since the wording is already written. Either way the cursor lands just past the inserted text.
+   A space is appended so typing continues without reaching for one; it is skipped when the following
+   text already begins with whitespace or with punctuation that should hug the reference
+   (`[Alice].`, `[Alice]'s`). `ComposeApp::save` trims, so that convenience space never reaches storage.
+10. The popup closes on its own when the reference is finished or abandoned: the slot's own closing
+    character in the query (`]` for the display slot, `)` for the target slot), the cursor moving back to
+    or past the opening bracket, or that bracket being deleted.
+11. With no matches, the popup says so rather than blocking: `Enter` falls through to a save, so a
+    brand-new entity name can be typed freely.
+12. Every frame re-renders the preview from the raw content, resolving markup to display text and
+    appending a `+new:` marker listing mentions absent from `known_lower`. Both the content field and
+    the preview word-wrap over as many rows as they need (`tui/compose/wrap.rs`), growing up to a cap
+    and then scrolling to keep the cursor's row visible — text past the right edge is wrapped, never
+    hidden.
+13. `Enter` calls `ComposeApp::save`, which resolves the date field and delegates to
+    `thought_writer::create_thought`.
+14. On success the content field is cleared, the date field is kept, the save counter increments, and
+    the candidates are reloaded so entities the save just created are immediately completable. The
+    composer stays open.
+15. `Esc` sets `should_quit`, the loop ends, `cli/add.rs` calls `ratatui::restore()` and prints how many
+    thoughts were added.
+
+## Data and state changes
+
+Each save inserts one row into `thoughts` and one row into `thought_entities` per resolved mention,
+creating rows in `entities` for names that match nothing — all inside a single transaction (see
+[`../systems/storage.md`](../systems/storage.md)). Nothing is written before `Enter`; abandoning the
+composer with `Esc` leaves the database untouched.
+
+An empty date field means "now" and stores a full timestamp; a filled one is pinned to midnight UTC on
+the resolved date. This mirrors `wet add` with and without `--date`.
+
+## Success behavior
+
+Each `Enter` reports `Saved thought #N (K entities) · M saved this session` in the status line, and the
+composer is ready for the next thought. On exit, `wet` prints the session total on stdout.
+
+## Failure behavior
+
+- **No terminal** — an `InvalidInput` error before any terminal setup, pointing at `wet add "..."`.
+- **Unparseable date** — the date field renders `→ unrecognized` with the accepted forms, in red, as you
+  type. `Enter` refuses to save and repeats the message in the status line; the content is untouched.
+- **Empty or oversized content** — `Thought::new`'s validation error lands in the status line and the
+  content is preserved so it can be corrected.
+- **Ambiguous alias** — as everywhere else, `entity_resolution` skips the link with a stderr warning
+  rather than failing the save (see [`entity-alias-resolution.md`](entity-alias-resolution.md)). Because
+  the composer owns the alternate screen, that warning is not visible until the composer exits.
+- **Storage failure mid-save** — the transaction rolls back, so no partially-linked thought survives;
+  the error appears in the status line and the composer stays open.
+
+## External dependencies
+
+A terminal supporting ratatui/crossterm. The database, per
+[`../systems/storage.md`](../systems/storage.md).
+
+## Invariants and assumptions
+
+- `cli/add.rs` always calls `ratatui::restore()` after `run` returns, whether it succeeded or errored —
+  the same explicit-teardown contract as `cli/tui.rs`, not a `Drop` impl.
+- `Whisperer::open_at` and `tui_input::Input::cursor` are both **codepoint** indices; mixing them with
+  byte offsets would split multibyte characters.
+- The candidate list and `known_lower` are only refreshed at startup and after a save. An entity created
+  by a concurrent `wet` invocation is not offered until the next save.
+- Accepting a completion rebuilds the whole `Input`, so any pending selection state in it is discarded.
+
+## Security and privacy notes
+
+Nothing beyond [`../systems/storage.md`](../systems/storage.md)'s notes on local data sensitivity.
+
+## Observability and debugging
+
+Save failures surface in the composer's status line, unlike the browser TUI's silently-swallowed delete
+errors. Warnings printed to stderr by `entity_resolution` are hidden by the alternate screen and only
+appear after exit. To reproduce composer behavior without a terminal, drive `handle_key_event` directly —
+that is what the unit tests do.
+
+## Testing notes
+
+- `src/tui/compose/input.rs` — key-handling tests covering the whisperer lifecycle (open, narrow, accept
+  canonical vs. alias, all four dismissal paths) and the field key map.
+- `src/tui/compose/ui.rs` — `TestBackend` render assertions for date resolution, the `+new` marker, the
+  popup contents, box growth and its cap, scrolling to the cursor, and narrow/multibyte terminals.
+- `src/tui/compose/wrap.rs` — wrapping in isolation: space vs. hard breaks, contiguous rows, cursor
+  location including row boundaries, and wide glyphs.
+- `src/tui/compose/mod.rs` — save semantics, including candidate reload after a save.
+- `tests/contract/test_add_command.rs` — that `wet add` without a terminal fails with a clear message,
+  and that relative `--date` values reach the CLI.
+
+## Source map
+
+- [`src/cli/add.rs`](../../src/cli/add.rs)
+- [`src/tui/compose/mod.rs`](../../src/tui/compose/mod.rs)
+- [`src/tui/compose/input.rs`](../../src/tui/compose/input.rs)
+- [`src/tui/compose/ui.rs`](../../src/tui/compose/ui.rs)
+- [`src/tui/compose/state.rs`](../../src/tui/compose/state.rs)
+- [`src/tui/compose/wrap.rs`](../../src/tui/compose/wrap.rs)
+- [`src/services/date_parser.rs`](../../src/services/date_parser.rs)
+- [`src/services/thought_writer.rs`](../../src/services/thought_writer.rs)
+
+## Related docs
+
+- [`../systems/cli.md`](../systems/cli.md), [`../systems/tui.md`](../systems/tui.md),
+  [`../systems/services.md`](../systems/services.md)
+- [`edit-thought.md`](edit-thought.md), [`entity-alias-resolution.md`](entity-alias-resolution.md)
+- [`../architecture/decisions/0015-interactive-thought-composer.md`](../architecture/decisions/0015-interactive-thought-composer.md)

--- a/docs/systems/cli.md
+++ b/docs/systems/cli.md
@@ -17,7 +17,8 @@ together `models`, `services`, and `storage`.
 
 ## Non-scope
 
-The TUI, launched by `wet tui` but documented separately (see [`tui.md`](tui.md)); the underlying
+The TUI, launched by `wet tui`, and the composer, launched by `wet add -i`, both documented separately
+(see [`tui.md`](tui.md)); the underlying
 repository/service logic each command calls (see [`storage.md`](storage.md), [`services.md`](services.md)).
 
 ## Key concepts
@@ -31,7 +32,7 @@ Global `--color` flag (`ColorMode`, see [`services.md`](services.md)). Subcomman
 
 | Subcommand | Args | Purpose | Source |
 |---|---|---|---|
-| `add` | `content`, `--date` | Add a new thought | `cli/add.rs` |
+| `add` | `content?`, `--date`, `-i`/`--interactive` (conflicts w/ content) | Add a new thought; without `content`, opens the interactive composer | `cli/add.rs` |
 | `thoughts` | `--on <entity>` | List thoughts, optionally filtered | `cli/thoughts.rs` |
 | `edit` | `id`, `content?`, `--date`, `--editor` (conflicts w/ content) | Edit a thought | `cli/edit.rs` |
 | `delete` | `id` | Delete a thought | `cli/delete.rs` |
@@ -54,11 +55,20 @@ commands (see [`storage.md`](storage.md)).
 
 **Notable per-command detail:**
 
-- `add.rs` — parses `--date` (`NaiveDate` "%Y-%m-%d" → midnight UTC) if given, saves the thought, then
-  extracts entities via `entity_parser::extract_unique_entities` and resolves each via
-  `entity_resolution::resolve_or_create_entity` (registered aliases resolve to their entity; unresolved
-  names still `find_or_create`; ambiguous aliases skip linking with a warning — see
-  [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)) before linking.
+- `add.rs` — with a `content` argument, parses `--date` via `date_parser::parse_date` (→ midnight UTC) if
+  given, then delegates to `thought_writer::create_thought`, which saves the thought and links its
+  mentions in one transaction: `entity_parser::extract_unique_entities` followed by
+  `entity_resolution::resolve_or_create_entity` per name (registered aliases resolve to their entity;
+  unresolved names still `find_or_create`; ambiguous aliases skip linking with a warning — see
+  [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)).
+  Without a `content` argument it opens the interactive composer instead — see
+  [`flows/add-thought-interactive.md`](../flows/add-thought-interactive.md) and [`tui.md`](tui.md). The
+  composer needs a TTY; without one, `add.rs` returns an `InvalidInput` error naming the non-interactive
+  form rather than starting ratatui. Terminal setup/teardown (`ratatui::init` / `ratatui::restore`)
+  happens here, matching `tui.rs`.
+- Both `--date` flags (`add` and `edit`) accept the forms in `date_parser` — `YYYY-MM-DD`, `today`,
+  `yesterday`, `tomorrow`, offsets like `-3d`/`-2w`/`-1m`, and weekday names. They set
+  `allow_hyphen_values` so `--date -3d` parses as a value rather than an unknown flag.
 - `thoughts.rs` — repository always returns ascending order; the command reverses the list if
   `SortOrder::Descending`. `--on <entity>` filtering includes thoughts tagged on any entity transitively
   reachable from `<entity>` via child relations, not just `<entity>` itself (see

--- a/docs/systems/services.md
+++ b/docs/systems/services.md
@@ -74,13 +74,22 @@ one entity, it prints a warning to stderr and returns `Ok(None)` — the mention
 any entity, no new entity created) without failing the caller's overall command. See
 [`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md).
 
-**`thought_writer.rs`** — `create_thought(conn, content, date) -> Result<(i64, Vec<String>), ThoughtError>`,
+`resolve_entity(conn, name) -> Result<Resolution, ThoughtError>` is the same logic without the printing:
+it returns `Resolution::Ambiguous(AmbiguousMention)` for the caller to render. `resolve_or_create_entity`
+is now a thin wrapper over it. **Anything that owns the terminal must use `resolve_entity`** — the
+composer holds the tty in raw mode on the alternate screen, and an `eprintln!` there lands mid-frame with
+no carriage return, which ratatui's diff-based redraw then leaves smeared for the rest of the session.
+`AmbiguousMention::describe()` gives both paths identical wording.
+
+**`thought_writer.rs`** — `create_thought(conn, content, date) -> Result<Created, ThoughtError>`,
 the other storage-touching function here. Builds and validates a `Thought` (`date` of `None` timestamps it
 with the current instant, `Some(date)` pins it to midnight UTC), then saves it and links each extracted
-mention via `entity_resolution::resolve_or_create_entity` — all inside one transaction, so a failure part
+mention via `entity_resolution::resolve_entity` — all inside one transaction, so a failure part
 way through leaves no orphan thought behind. Shared by `wet add` and the interactive composer, which is why
-both cannot drift apart on what "adding a thought" means. Returns the new ID and the unique entity names
-extracted from the content; a name skipped as an ambiguous alias is counted in that list but not linked.
+both cannot drift apart on what "adding a thought" means. Returns a `Created { id, entities, ambiguous }`: the new ID, the unique entity
+names extracted from the content, and any mentions left unlinked because their alias was ambiguous.
+Ambiguity is *returned* rather than printed so a caller that owns the terminal can render it itself —
+see `entity_resolution` below.
 
 **`date_parser.rs`** — `parse_date_from(input, today)` / `parse_date(input)`, the single definition of
 what a date may look like anywhere in the app. Accepts, case-insensitively and trimmed: `YYYY-MM-DD`;

--- a/docs/systems/services.md
+++ b/docs/systems/services.md
@@ -3,21 +3,23 @@
 ## Purpose
 
 Pure business-logic helpers with no I/O or persistence dependencies — entity-reference parsing, entity
-color styling, description-preview formatting, and terminal color-mode detection — plus one small
-DB-touching helper, `entity_resolution`, that ties `[bracket]` mention extraction to the persisted alias
-registry. Reused by both the CLI and the TUI.
+color styling, description-preview formatting, date parsing, and terminal color-mode detection — plus two
+DB-touching helpers: `entity_resolution`, which ties `[bracket]` mention extraction to the persisted alias
+registry, and `thought_writer`, which persists a new thought and its links. Reused by both the CLI and the
+TUI.
 
 ## Questions this doc answers
 
 - What syntax does an entity reference use, and how is it parsed?
 - How are entities colored/styled in output?
 - How are entity description previews generated?
+- What date formats are accepted, and where is that decided?
 - How is color output enabled/disabled?
 
 ## Scope
 
-`src/services/color_mode.rs`, `entity_parser.rs`, `entity_styler.rs`, `description_formatter.rs`,
-`entity_resolution.rs`.
+`src/services/color_mode.rs`, `date_parser.rs`, `entity_parser.rs`, `entity_styler.rs`,
+`description_formatter.rs`, `entity_resolution.rs`, `thought_writer.rs`.
 
 ## Non-scope
 
@@ -71,6 +73,24 @@ creating a brand-new literal entity when nothing matches. If `name` is an alias 
 one entity, it prints a warning to stderr and returns `Ok(None)` — the mention is skipped (not linked to
 any entity, no new entity created) without failing the caller's overall command. See
 [`../flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md).
+
+**`thought_writer.rs`** — `create_thought(conn, content, date) -> Result<(i64, Vec<String>), ThoughtError>`,
+the other storage-touching function here. Builds and validates a `Thought` (`date` of `None` timestamps it
+with the current instant, `Some(date)` pins it to midnight UTC), then saves it and links each extracted
+mention via `entity_resolution::resolve_or_create_entity` — all inside one transaction, so a failure part
+way through leaves no orphan thought behind. Shared by `wet add` and the interactive composer, which is why
+both cannot drift apart on what "adding a thought" means. Returns the new ID and the unique entity names
+extracted from the content; a name skipped as an ambiguous alias is counted in that list but not linked.
+
+**`date_parser.rs`** — `parse_date_from(input, today)` / `parse_date(input)`, the single definition of
+what a date may look like anywhere in the app. Accepts, case-insensitively and trimmed: `YYYY-MM-DD`;
+`today`/`t`, `yesterday`/`y`, `tomorrow`; signed offsets `-3d`, `-2w`, `-1m` (a leading `+` or no sign
+moves forward); and weekday names in full or three-letter form, resolving to the most recent occurrence
+at or before `today`. Month arithmetic clamps to the end of a shorter month, so `-1m` from March 31 is
+the last day of February. Anything else is an `InvalidInput` naming the accepted forms, which are also
+exported as `ACCEPTED_FORMS` for the composer's inline hint. `parse_date_from` takes `today` explicitly so
+the behavior is testable without freezing the clock. Used by `wet add --date`, `wet edit --date`, and the
+composer's date field.
 
 **`entity_styler.rs`** — `EntityStyler { color_map, next_color, use_colors }`. Cycles through a 12-color
 palette (excluding black/white). `EntityStyler::new(use_colors)`, `render_content(&mut self, content) ->
@@ -155,11 +175,15 @@ bare references, nested-looking brackets) and the preview pipeline's truncation 
 - [`src/services/entity_styler.rs`](../../src/services/entity_styler.rs)
 - [`src/services/description_formatter.rs`](../../src/services/description_formatter.rs)
 - [`src/services/color_mode.rs`](../../src/services/color_mode.rs)
+- [`src/services/date_parser.rs`](../../src/services/date_parser.rs)
+- [`src/services/entity_resolution.rs`](../../src/services/entity_resolution.rs)
+- [`src/services/thought_writer.rs`](../../src/services/thought_writer.rs)
 
 ## Related docs
 
 - [`cli.md`](cli.md), [`tui.md`](tui.md) — consumers.
 - [`flows/entity-rename.md`](../flows/entity-rename.md)
+- [`flows/add-thought-interactive.md`](../flows/add-thought-interactive.md)
 - [Glossary: Entity Reference, Alias, Color Mode, Description Preview](../glossary.md)
 - [`flows/entity-alias-resolution.md`](../flows/entity-alias-resolution.md)
 - [`../architecture/decisions/0013-entity-aliases.md`](../architecture/decisions/0013-entity-aliases.md)

--- a/docs/systems/tui.md
+++ b/docs/systems/tui.md
@@ -136,6 +136,7 @@ pub struct ComposeApp {
     pub status: Option<Status>,        // Saved { id, entities } | Error(String)
     pub saved_count: usize,
     pub should_quit: bool,
+    pub pending_quit: bool,            // an Esc on unsaved text, awaiting confirmation
     conn: Connection,
 }
 ```
@@ -153,6 +154,10 @@ must make newly created entities completable right away.
 `Tab`/`BackTab` switch focus, `Enter` saves, `Esc`/`Ctrl-C` quit, anything else goes to the focused
 input. With it open: arrows move the highlight, `Tab`/`Enter` accept, `Esc` dismisses while keeping the
 typed text, anything else edits the content and re-runs `recompute_whisperer`.
+
+`Esc` with no popup open quits only when the thought field is empty; with unsaved text it arms
+`pending_quit` and reports it in the status line, and any other key disarms it. Discarding written text
+is the composer's one destructive dismissal, so it is the one that asks first.
 
 Two bindings sit above both maps and fire from anywhere: `Ctrl-C` quits, and `Alt-Left`/`Alt-Right` call
 `ComposeApp::nudge_date(±1)`, shifting the date a day without moving focus — a one-day correction should
@@ -185,6 +190,10 @@ is what makes mapping a cursor index onto a row unambiguous. Breaks prefer the l
 Widths are display columns via `unicode-width`, not character counts, so wide glyphs cannot overflow
 and be clipped. Rendering and cursor placement both consume one `Wrapped`, so they cannot disagree.
 
+`compose/mod.rs`'s `selectable_candidates(slot)` filters what the whisperer may offer: in the target
+slot it drops entities whose canonical name contains a paren, since `ENTITY_PATTERN`'s target group
+cannot span one and accepting such a candidate would silently misparse into a new entity.
+
 `compose/ui.rs` — a vertical layout of date field, content field, preview, status, and a two-line
 syntax help footer. The date field re-parses on every frame and shows the resolved date or the accepted
 forms in red; when the input is already an absolute `YYYY-MM-DD` — which it always is after a nudge —
@@ -192,7 +201,9 @@ it shows only the weekday rather than echoing the date back. The content and pre
 their text**, capped at `CONTENT_MAX_ROWS` / `PREVIEW_MAX_ROWS` so the footer is never pushed off
 screen; past the content cap the field scrolls to keep the cursor's row in view. The preview wraps via
 `Paragraph::wrap` and therefore calls `styled_content_line` with an effectively unlimited width — it
-must not truncate, since wrapping is what shows the rest. The preview runs the raw content through `ui::styled_content_line` and appends a
+must not truncate, since wrapping is what shows the rest. The `+new:` marker gets its own reserved row
+below the text rather than trailing it: appended inline it was the first thing wrapping dropped, so it
+vanished on exactly the long thoughts where a typo is most likely. The preview runs the raw content through `ui::styled_content_line` and appends a
 `+new:` list of mentions missing from `known_lower`. The whisperer popup tracks the cursor's column but
 hangs below the preview, so the preview stays readable while completing.
 

--- a/docs/systems/tui.md
+++ b/docs/systems/tui.md
@@ -2,18 +2,20 @@
 
 ## Purpose
 
-The interactive terminal viewer (`wet tui`) for browsing, filtering, sorting, and deleting thoughts —
-built on `ratatui` with a classic Elm-style state/input/ui split.
+The interactive terminal viewer (`wet tui`) for browsing, filtering, sorting, and deleting thoughts, and
+the interactive composer (`wet add -i`) for entering new ones — both built on `ratatui` with a classic
+Elm-style state/input/ui split.
 
 ## Questions this doc answers
 
 - How is the TUI structured (state machine, event loop)?
 - What does each `Mode` do?
+- How does the composer's entity whisperer decide what to offer and when to close?
 - Why might an entity's color differ between the CLI and the TUI?
 
 ## Scope
 
-`src/tui/mod.rs`, `state.rs`, `input.rs`, `ui.rs`.
+`src/tui/mod.rs`, `state.rs`, `input.rs`, `ui.rs`, `fuzzy.rs`, and `src/tui/compose/`.
 
 ## Non-scope
 
@@ -109,10 +111,95 @@ enum Mode {
 `ui.rs` — pure rendering, `render(app, frame)`: splits the screen into a thought list (min 3 rows) + a
 1-row status bar, then overlays the active mode's popup (`ConfirmDelete`/`EntityPicker`/`EntityDetail`)
 via `Clear` + a centered `Rect`. Also implements its own entity color assignment — see Common Pitfalls.
+Its `styled_content_line` is `pub(crate)` and shared with the composer's preview.
+
+`fuzzy.rs` — `score_all(query, haystacks)` / `match_indices(query, haystacks)` wrap `nucleo_matcher`
+(`CaseMatching::Ignore`, `Normalization::Smart`, `AtomKind::Fuzzy`), sorted by descending score with
+input order preserved on ties. Both the browser's entity picker and the composer's whisperer score
+through it, so their matching behavior cannot drift apart. An empty query matches everything, in order.
+
+### The composer (`src/tui/compose/`)
+
+A second, independent ratatui app reached via `wet add -i` (or bare `wet add`), with the same
+`mod`/`state`/`input`/`ui` split. See
+[`../architecture/decisions/0015-interactive-thought-composer.md`](../architecture/decisions/0015-interactive-thought-composer.md)
+for why it is separate from the browser rather than an `a` key inside it.
+
+```rust
+pub struct ComposeApp {
+    pub content: tui_input::Input,
+    pub date: tui_input::Input,
+    pub focus: Field,                  // Date | Content
+    pub candidates: Vec<Candidate>,    // canonical names *and* aliases
+    pub known_lower: HashSet<String>,  // for the "+new" preview marker
+    pub whisperer: Option<Whisperer>,
+    pub status: Option<Status>,        // Saved { id, entities } | Error(String)
+    pub saved_count: usize,
+    pub should_quit: bool,
+    conn: Connection,
+}
+```
+
+Unlike `App`, which is handed pre-loaded data and reopens a connection per mutation, `ComposeApp` owns
+one connection for its whole session and loads its own candidates — it writes repeatedly, and each save
+must make newly created entities completable right away.
+
+`compose/state.rs` holds pure data: `Field`, `Candidate { label, canonical, is_alias, description }`,
+`Slot` (`Display` | `Target`), and `Whisperer { open_at, slot, matches, selected }`.
+`Candidate::insertion(slot)` yields `[Name]` or `[alias](Name)` in the `Display` slot, and bare
+`(Name)` in the `Target` slot.
+
+`compose/input.rs` — `handle_key_event` picks one of two key maps. With the whisperer closed:
+`Tab`/`BackTab` switch focus, `Enter` saves, `Esc`/`Ctrl-C` quit, anything else goes to the focused
+input. With it open: arrows move the highlight, `Tab`/`Enter` accept, `Esc` dismisses while keeping the
+typed text, anything else edits the content and re-runs `recompute_whisperer`.
+
+Two bindings sit above both maps and fire from anywhere: `Ctrl-C` quits, and `Alt-Left`/`Alt-Right` call
+`ComposeApp::nudge_date(±1)`, shifting the date a day without moving focus — a one-day correction should
+not cost a field round-trip. `tui_input` leaves `Alt`-arrows unbound (it claims the `Ctrl` variants for
+word movement), so nothing is clobbered. `nudge_date` rewrites the field as an absolute `YYYY-MM-DD` so
+repeated nudges compose; an empty field counts as today, and a field that does not parse is left alone
+rather than overwriting a half-typed value.
+
+`recompute_whisperer` is the whole popup lifecycle, and there are two triggers:
+
+- **`[` opens the `Display` slot**, anchored at that bracket. Accepting writes a whole reference.
+- **`(` typed straight after a `]` opens the `Target` slot**, anchored at the paren. This is the path for
+  a reference whose display wording was written by hand — `met [my boss](…` — where the wording will
+  never fuzzy-match anything. Accepting writes only `(Canonical)`, leaving the wording alone; picking a
+  registered alias here contributes its canonical name, never `[my boss](alicia)`. `(` only triggers
+  directly after a `]`, so ordinary parenthetical prose does not open the popup.
+
+While open, the query is the content between the opening bracket and the cursor, scored via `fuzzy`. It
+closes when the reference is finished or abandoned: the slot's own closing character in the query
+(`]` for `Display`, `)` for `Target`), the cursor moving back to or past the opening bracket, or that
+bracket being deleted. With no matches the popup says so and lets `Enter` fall through to a save, so
+free-form entity names still work.
+
+`compose/wrap.rs` — `wrap(text, cursor, width) -> Wrapped { rows, cursor_row, cursor_col }`, the
+composer's word wrapping. `tui_input::Input` holds one logical line with no newlines, but a thought
+easily runs past the right edge, so the content is laid out over visual rows here. Rows are half-open
+character ranges that **tile the content exactly** — every character belongs to exactly one row, which
+is what makes mapping a cursor index onto a row unambiguous. Breaks prefer the last space on a row
+(kept at that row's end, so the ranges stay contiguous); a word longer than the field is broken hard.
+Widths are display columns via `unicode-width`, not character counts, so wide glyphs cannot overflow
+and be clipped. Rendering and cursor placement both consume one `Wrapped`, so they cannot disagree.
+
+`compose/ui.rs` — a vertical layout of date field, content field, preview, status, and a two-line
+syntax help footer. The date field re-parses on every frame and shows the resolved date or the accepted
+forms in red; when the input is already an absolute `YYYY-MM-DD` — which it always is after a nudge —
+it shows only the weekday rather than echoing the date back. The content and preview boxes **grow with
+their text**, capped at `CONTENT_MAX_ROWS` / `PREVIEW_MAX_ROWS` so the footer is never pushed off
+screen; past the content cap the field scrolls to keep the cursor's row in view. The preview wraps via
+`Paragraph::wrap` and therefore calls `styled_content_line` with an effectively unlimited width — it
+must not truncate, since wrapping is what shows the rest. The preview runs the raw content through `ui::styled_content_line` and appends a
+`+new:` list of mentions missing from `known_lower`. The whisperer popup tracks the cursor's column but
+hangs below the preview, so the preview stays readable while completing.
 
 ## Important flows
 
 - [`../flows/tui-entity-filter.md`](../flows/tui-entity-filter.md)
+- [`../flows/add-thought-interactive.md`](../flows/add-thought-interactive.md)
 
 Thought deletion (`x` + confirm overlay, vs. the CLI's unconfirmed `wet delete`) is covered inline above
 and in [`cli.md`](cli.md#how-the-system-works), rather than as a standalone flow doc.
@@ -123,10 +210,13 @@ The TUI loads all thoughts, entities, and relation edges **once at startup** (`c
 re-query the database during the session. Deletions mutate in-memory state directly and also delete from
 the DB. A relation added or removed via the CLI mid-session is not reflected until the TUI restarts.
 
+The composer likewise snapshots its candidates, but refreshes them after every save. An entity created by
+a concurrent `wet` invocation is not offered until the next save.
+
 ## Interfaces and entry points
 
 `App::new`, `App::with_db_path`, `App::with_relations`, `App::run`; launched via `wet tui`
-([`cli.md`](cli.md)).
+([`cli.md`](cli.md)). `ComposeApp::new`, `ComposeApp::run`; launched via `wet add -i`.
 
 ## Dependencies
 
@@ -144,14 +234,23 @@ a TUI session could observe a delete after the fact, but there's no locking beyo
 - `cli/tui.rs::execute` (not `App::run` itself) always calls `ratatui::restore()` after `App::run`
   returns, whether `run()` succeeded or errored — this relies on the caller doing so explicitly, not on a
   `Drop` impl on `App`, and doesn't cover a hard process panic (relies on `ratatui`'s own panic hook, if
-  any, not an explicit `catch_unwind`).
+  any, not an explicit `catch_unwind`). `cli/add.rs` carries the same contract for `ComposeApp::run`.
 - `displayed_thoughts` must be recomputed any time `active_filter`, `sort_order`, or `thoughts` changes —
   it is not automatically kept in sync.
+- `Whisperer::open_at` and `tui_input::Input::cursor` are both **codepoint** indices. Anything that
+  slices content by them must convert to byte offsets, or it will split multibyte characters.
+- `wrap::Row` ranges are also codepoint indices, and must stay contiguous and cover the whole content:
+  `locate_cursor` assumes every character belongs to exactly one row.
+- The rendered content rows and the cursor position must come from the **same** `wrap::Wrapped` value.
+  Recomputing either independently reintroduces the drift the module exists to prevent.
 
 ## Error handling
 
 `delete_selected_thought` returns `Result<(), ThoughtError>`; the `ConfirmDelete` key handler swallows an
 error by falling back to `Normal` mode silently (no error message shown to the user in-TUI).
+
+The composer is the opposite: `ComposeApp::save` records every failure in `status` and renders it in the
+status line, keeping the content so it can be corrected.
 
 ## Security and privacy notes
 
@@ -169,6 +268,11 @@ itself.
 are testable without a terminal; `input.rs`'s handlers are testable by constructing `App` + `KeyEvent`
 directly. Rendering (`ui.rs`) is harder to test and typically verified manually.
 
+The composer is covered more thoroughly: `compose/mod.rs`'s `test_support` builds a `ComposeApp` over an
+in-memory database seeded with an entity, an alias, and a description, and drives real keystrokes through
+`handle_key_event`. `compose/ui.rs` renders through `ratatui::backend::TestBackend` and asserts on the
+flattened buffer, including narrow-terminal and multibyte cases.
+
 ## Common pitfalls
 
 - **`ui.rs`'s `entity_color`/`entity_color_index` use a separate, hash-based color-assignment algorithm**
@@ -185,11 +289,20 @@ directly. Rendering (`ui.rs`) is harder to test and typically verified manually.
 - [`src/tui/state.rs`](../../src/tui/state.rs)
 - [`src/tui/input.rs`](../../src/tui/input.rs)
 - [`src/tui/ui.rs`](../../src/tui/ui.rs)
+- [`src/tui/fuzzy.rs`](../../src/tui/fuzzy.rs) — shared candidate scoring.
+- [`src/tui/compose/mod.rs`](../../src/tui/compose/mod.rs) — composer state and event loop.
+- [`src/tui/compose/state.rs`](../../src/tui/compose/state.rs)
+- [`src/tui/compose/input.rs`](../../src/tui/compose/input.rs) — whisperer lifecycle.
+- [`src/tui/compose/ui.rs`](../../src/tui/compose/ui.rs)
+- [`src/tui/compose/wrap.rs`](../../src/tui/compose/wrap.rs) — word wrapping and cursor location.
 - [`src/cli/tui.rs`](../../src/cli/tui.rs) — startup/data loading.
+- [`src/cli/add.rs`](../../src/cli/add.rs) — composer startup/teardown.
 
 ## Related docs
 
 - [`services.md`](services.md), [`storage.md`](storage.md), [`cli.md`](cli.md)
 - [`../flows/tui-entity-filter.md`](../flows/tui-entity-filter.md)
+- [`../flows/add-thought-interactive.md`](../flows/add-thought-interactive.md)
 - [`../architecture/decisions/0006-tui-viewer.md`](../architecture/decisions/0006-tui-viewer.md)
 - [`../architecture/decisions/0012-entity-relations.md`](../architecture/decisions/0012-entity-relations.md)
+- [`../architecture/decisions/0015-interactive-thought-composer.md`](../architecture/decisions/0015-interactive-thought-composer.md)

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -3,15 +3,28 @@ use crate::errors::ThoughtError;
 use crate::services::{date_parser, thought_writer};
 use crate::storage::connection::get_connection;
 use crate::storage::migrations::run_migrations;
+use crate::tui::compose::ComposeApp;
+use std::io::IsTerminal;
 use std::path::Path;
 
 /// Execute the add command
 ///
+/// With `content`, saves the thought directly. Without it, opens the interactive
+/// composer, which offers entity completion, relative-date help, and a live preview.
+///
 /// # Arguments
-/// * `content` - Text of the thought, including any `[Entity]` mentions
+/// * `content` - Text of the thought, including any `[Entity]` mentions; `None` composes interactively
 /// * `date` - Optional date string; see [`date_parser`] for the accepted forms
 /// * `db_path` - Path to the SQLite database file
-pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
+pub fn execute(content: Option<String>, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
+    match content {
+        Some(content) => add_directly(content, date, db_path),
+        None => compose_interactively(date, db_path),
+    }
+}
+
+/// Save a thought supplied on the command line.
+fn add_directly(content: String, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
     let date = date.as_deref().map(date_parser::parse_date).transpose()?;
 
     let mut conn = get_connection(db_path)?;
@@ -29,6 +42,33 @@ pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<
             entity_names.len(),
             if entity_names.len() == 1 { "" } else { "s" }
         );
+    }
+
+    Ok(())
+}
+
+/// Open the interactive composer, restoring the terminal however it exits.
+fn compose_interactively(date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
+    if !std::io::stdin().is_terminal() || !std::io::stdout().is_terminal() {
+        return Err(ThoughtError::InvalidInput(
+            "The interactive composer needs a terminal. Pass the thought as an argument instead: wet add \"...\"."
+                .to_string(),
+        ));
+    }
+
+    let conn = get_connection(db_path)?;
+    run_migrations(&conn)?;
+    let mut app = ComposeApp::new(conn, date)?;
+
+    let mut terminal = ratatui::init();
+    let result = app.run(&mut terminal);
+    ratatui::restore();
+    result?;
+
+    match app.saved_count {
+        0 => println!("No thoughts added."),
+        1 => println!("1 thought added."),
+        n => println!("{} thoughts added.", n),
     }
 
     Ok(())

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,21 +1,23 @@
 /// Add command implementation
 use crate::errors::ThoughtError;
 use crate::models::thought::Thought;
-use crate::services::{entity_parser, entity_resolution};
+use crate::services::{date_parser, entity_parser, entity_resolution};
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
-use chrono::NaiveDate;
 use std::path::Path;
 
 /// Execute the add command
+///
+/// # Arguments
+/// * `content` - Text of the thought, including any `[Entity]` mentions
+/// * `date` - Optional date string; see [`date_parser`] for the accepted forms
+/// * `db_path` - Path to the SQLite database file
 pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
     // Create and validate thought
     let thought = if let Some(ref date_str) = date {
-        let naive = NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {
-            ThoughtError::InvalidInput(format!("Invalid date format '{}'. Expected YYYY-MM-DD.", date_str))
-        })?;
+        let naive = date_parser::parse_date(date_str)?;
         let datetime = naive.and_hms_opt(0, 0, 0).unwrap().and_utc();
         Thought::new_with_date(content.clone(), datetime)?
     } else {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -1,11 +1,8 @@
 /// Add command implementation
 use crate::errors::ThoughtError;
-use crate::models::thought::Thought;
-use crate::services::{date_parser, entity_parser, entity_resolution};
+use crate::services::{date_parser, thought_writer};
 use crate::storage::connection::get_connection;
-use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
-use crate::storage::thoughts_repository::ThoughtsRepository;
 use std::path::Path;
 
 /// Execute the add command
@@ -15,31 +12,12 @@ use std::path::Path;
 /// * `date` - Optional date string; see [`date_parser`] for the accepted forms
 /// * `db_path` - Path to the SQLite database file
 pub fn execute(content: String, date: Option<String>, db_path: &Path) -> Result<(), ThoughtError> {
-    // Create and validate thought
-    let thought = if let Some(ref date_str) = date {
-        let naive = date_parser::parse_date(date_str)?;
-        let datetime = naive.and_hms_opt(0, 0, 0).unwrap().and_utc();
-        Thought::new_with_date(content.clone(), datetime)?
-    } else {
-        Thought::new(content.clone())?
-    };
+    let date = date.as_deref().map(date_parser::parse_date).transpose()?;
 
-    // Get database connection
-    let conn = get_connection(db_path)?;
-
-    // Run migrations if needed
+    let mut conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 
-    // Save thought
-    let thought_id = ThoughtsRepository::save(&conn, &thought)?;
-
-    // Extract and save entities
-    let entity_names = entity_parser::extract_unique_entities(&content);
-    for entity_name in &entity_names {
-        if let Some(entity_id) = entity_resolution::resolve_or_create_entity(&conn, entity_name)? {
-            EntitiesRepository::link_to_thought(&conn, entity_id, thought_id)?;
-        }
-    }
+    let (thought_id, entity_names) = thought_writer::create_thought(&mut conn, &content, date)?;
 
     // Success message with entity count
     if entity_names.is_empty() {

--- a/src/cli/add.rs
+++ b/src/cli/add.rs
@@ -30,17 +30,22 @@ fn add_directly(content: String, date: Option<String>, db_path: &Path) -> Result
     let mut conn = get_connection(db_path)?;
     run_migrations(&conn)?;
 
-    let (thought_id, entity_names) = thought_writer::create_thought(&mut conn, &content, date)?;
+    let created = thought_writer::create_thought(&mut conn, &content, date)?;
+
+    // Ambiguous mentions are reported, not linked; warn but do not fail.
+    for ambiguous in &created.ambiguous {
+        eprintln!("Warning: {}", ambiguous.describe());
+    }
 
     // Success message with entity count
-    if entity_names.is_empty() {
-        println!("Thought added successfully (ID: {})", thought_id);
+    if created.entities.is_empty() {
+        println!("Thought added successfully (ID: {})", created.id);
     } else {
         println!(
             "Thought added successfully (ID: {}, {} entity reference{})",
-            thought_id,
-            entity_names.len(),
-            if entity_names.len() == 1 { "" } else { "s" }
+            created.id,
+            created.entities.len(),
+            if created.entities.len() == 1 { "" } else { "s" }
         );
     }
 
@@ -63,13 +68,14 @@ fn compose_interactively(date: Option<String>, db_path: &Path) -> Result<(), Tho
     let mut terminal = ratatui::init();
     let result = app.run(&mut terminal);
     ratatui::restore();
-    result?;
 
+    // Report the count before propagating: those saves are already committed, and
+    // a terminal error must not leave the user unsure whether their work landed.
     match app.saved_count {
         0 => println!("No thoughts added."),
         1 => println!("1 thought added."),
         n => println!("{} thoughts added.", n),
     }
 
-    Ok(())
+    result
 }

--- a/src/cli/edit.rs
+++ b/src/cli/edit.rs
@@ -1,12 +1,11 @@
 /// Edit command implementation
 use crate::errors::ThoughtError;
 use crate::input::editor;
-use crate::services::{entity_parser, entity_resolution};
+use crate::services::{date_parser, entity_parser, entity_resolution};
 use crate::storage::connection::get_connection;
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::migrations::run_migrations;
 use crate::storage::thoughts_repository::ThoughtsRepository;
-use chrono::NaiveDate;
 use std::path::Path;
 
 /// Execute the edit command
@@ -18,7 +17,7 @@ use std::path::Path;
 /// # Arguments
 /// * `id` - Numeric ID of the thought to edit (shown as `[id]` in `wet` listing)
 /// * `content` - Optional new text content for the thought
-/// * `date` - Optional new date string in YYYY-MM-DD format
+/// * `date` - Optional new date string; see [`date_parser`] for the accepted forms
 /// * `use_editor` - If true, open the thought's current content in an interactive editor
 /// * `db_path` - Optional path to the SQLite database file
 pub fn execute(
@@ -75,9 +74,7 @@ pub fn execute(
 
     // Parse new date if provided
     let new_date = if let Some(ref date_str) = date {
-        let naive = NaiveDate::parse_from_str(date_str, "%Y-%m-%d").map_err(|_| {
-            ThoughtError::InvalidInput(format!("Invalid date format '{}'. Expected YYYY-MM-DD.", date_str))
-        })?;
+        let naive = date_parser::parse_date(date_str)?;
         Some(naive.and_hms_opt(0, 0, 0).unwrap().and_utc())
     } else {
         None

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -34,8 +34,9 @@ pub enum Commands {
     Add {
         /// Thought content
         content: String,
-        /// Date for the thought in YYYY-MM-DD format (defaults to today)
-        #[arg(long)]
+        /// Date for the thought: YYYY-MM-DD, today, yesterday, -3d, or a weekday (defaults to now)
+        // Hyphen values so negative offsets like `--date -3d` parse as a value, not a flag.
+        #[arg(long, allow_hyphen_values = true)]
         date: Option<String>,
     },
     /// List all thoughts
@@ -50,8 +51,9 @@ pub enum Commands {
         id: i64,
         /// New content for the thought (mutually exclusive with --editor)
         content: Option<String>,
-        /// New date for the thought in YYYY-MM-DD format
-        #[arg(long)]
+        /// New date for the thought: YYYY-MM-DD, today, yesterday, -3d, or a weekday
+        // Hyphen values so negative offsets like `--date -3d` parse as a value, not a flag.
+        #[arg(long, allow_hyphen_values = true)]
         date: Option<String>,
         /// Open the thought in an interactive editor (mutually exclusive with CONTENT)
         #[arg(long, conflicts_with = "content")]

--- a/src/cli/mod.rs
+++ b/src/cli/mod.rs
@@ -32,12 +32,15 @@ pub struct Cli {
 pub enum Commands {
     /// Add a new thought
     Add {
-        /// Thought content
-        content: String,
+        /// Thought content (omit to open the interactive composer)
+        content: Option<String>,
         /// Date for the thought: YYYY-MM-DD, today, yesterday, -3d, or a weekday (defaults to now)
         // Hyphen values so negative offsets like `--date -3d` parse as a value, not a flag.
         #[arg(long, allow_hyphen_values = true)]
         date: Option<String>,
+        /// Compose the thought interactively, with entity completion and date help
+        #[arg(short, long, conflicts_with = "content")]
+        interactive: bool,
     },
     /// List all thoughts
     Thoughts {

--- a/src/main.rs
+++ b/src/main.rs
@@ -46,7 +46,13 @@ fn main() {
         Commands::Config { key, value } => wetware::cli::config::execute(&data_dir, key, value),
         Commands::Delete { id } => wetware::cli::delete::execute(id, &db_path),
         Commands::Tui => wetware::cli::tui::execute(&db_path, config.thoughts.order),
-        Commands::Add { content, date } => wetware::cli::add::execute(content, date, &db_path),
+        // `interactive` only forces the composer when content is absent, which is
+        // already what an absent content argument means.
+        Commands::Add {
+            content,
+            date,
+            interactive: _,
+        } => wetware::cli::add::execute(content, date, &db_path),
         Commands::Edit {
             id,
             content,

--- a/src/services/date_parser.rs
+++ b/src/services/date_parser.rs
@@ -1,0 +1,235 @@
+//! Date parsing service - turns user-supplied date strings into calendar dates.
+//!
+//! Shared by `wet add --date`, `wet edit --date`, and the interactive composer's
+//! date field, so all three accept exactly the same forms.
+
+use crate::errors::ThoughtError;
+use chrono::{Datelike, Days, Months, NaiveDate, Utc, Weekday};
+
+/// Human-readable summary of the accepted forms, used in error messages and
+/// in the composer's help footer.
+pub const ACCEPTED_FORMS: &str = "YYYY-MM-DD, today, yesterday, tomorrow, -3d/-2w/-1m, or a weekday name";
+
+/// Parse a user-supplied date string relative to `today`.
+///
+/// Accepted forms (case-insensitive, surrounding whitespace ignored):
+///
+/// - `2026-08-01` - an absolute ISO date
+/// - `today` / `t`, `yesterday` / `y`, `tomorrow`
+/// - `-3d`, `-2w`, `-1m` - that many days, weeks, or months back. A leading `+`
+///   (or no sign) moves forward instead: `+3d`, `3d`.
+/// - `mon`..`sun` or `monday`..`sunday` - the most recent occurrence of that
+///   weekday, which is `today` when today is that weekday.
+///
+/// Month arithmetic clamps to the end of the target month, so `-1m` from
+/// March 31 is the last day of February.
+pub fn parse_date_from(input: &str, today: NaiveDate) -> Result<NaiveDate, ThoughtError> {
+    let raw = input.trim();
+    if raw.is_empty() {
+        return Err(invalid(input));
+    }
+    let lower = raw.to_lowercase();
+
+    if let Ok(date) = NaiveDate::parse_from_str(&lower, "%Y-%m-%d") {
+        return Ok(date);
+    }
+
+    match lower.as_str() {
+        "today" | "t" => return Ok(today),
+        "yesterday" | "y" => return today.checked_sub_days(Days::new(1)).ok_or_else(|| invalid(input)),
+        "tomorrow" => return today.checked_add_days(Days::new(1)).ok_or_else(|| invalid(input)),
+        _ => {}
+    }
+
+    if let Some(weekday) = parse_weekday(&lower) {
+        return Ok(most_recent_weekday(today, weekday));
+    }
+
+    if let Some(date) = parse_offset(&lower, today) {
+        return Ok(date);
+    }
+
+    Err(invalid(input))
+}
+
+/// Parse a user-supplied date string relative to the current UTC date.
+pub fn parse_date(input: &str) -> Result<NaiveDate, ThoughtError> {
+    parse_date_from(input, Utc::now().date_naive())
+}
+
+fn invalid(input: &str) -> ThoughtError {
+    ThoughtError::InvalidInput(format!("Invalid date '{}'. Expected {}.", input.trim(), ACCEPTED_FORMS))
+}
+
+/// Match full or three-letter weekday names.
+fn parse_weekday(lower: &str) -> Option<Weekday> {
+    match lower {
+        "mon" | "monday" => Some(Weekday::Mon),
+        "tue" | "tuesday" => Some(Weekday::Tue),
+        "wed" | "wednesday" => Some(Weekday::Wed),
+        "thu" | "thursday" => Some(Weekday::Thu),
+        "fri" | "friday" => Some(Weekday::Fri),
+        "sat" | "saturday" => Some(Weekday::Sat),
+        "sun" | "sunday" => Some(Weekday::Sun),
+        _ => None,
+    }
+}
+
+/// The most recent occurrence of `weekday` at or before `today`.
+fn most_recent_weekday(today: NaiveDate, weekday: Weekday) -> NaiveDate {
+    let back = today.weekday().num_days_from_monday() as i64 - weekday.num_days_from_monday() as i64;
+    let back = back.rem_euclid(7) as u64;
+    today
+        .checked_sub_days(Days::new(back))
+        .expect("subtracting at most 6 days from a valid date cannot overflow")
+}
+
+/// Parse a signed offset like `-3d`, `+2w`, `1m`.
+fn parse_offset(lower: &str, today: NaiveDate) -> Option<NaiveDate> {
+    let (negative, rest) = match lower.strip_prefix('-') {
+        Some(rest) => (true, rest),
+        None => (false, lower.strip_prefix('+').unwrap_or(lower)),
+    };
+
+    let unit = rest.chars().last()?;
+    let digits = &rest[..rest.len() - unit.len_utf8()];
+    if digits.is_empty() || !digits.chars().all(|c| c.is_ascii_digit()) {
+        return None;
+    }
+    let amount: u32 = digits.parse().ok()?;
+
+    match unit {
+        'd' => shift_days(today, amount as u64, negative),
+        'w' => shift_days(today, amount as u64 * 7, negative),
+        'm' => {
+            let months = Months::new(amount);
+            if negative {
+                today.checked_sub_months(months)
+            } else {
+                today.checked_add_months(months)
+            }
+        }
+        _ => None,
+    }
+}
+
+fn shift_days(today: NaiveDate, amount: u64, negative: bool) -> Option<NaiveDate> {
+    let days = Days::new(amount);
+    if negative {
+        today.checked_sub_days(days)
+    } else {
+        today.checked_add_days(days)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Friday, 2026-08-07.
+    fn today() -> NaiveDate {
+        NaiveDate::from_ymd_opt(2026, 8, 7).unwrap()
+    }
+
+    fn parse(input: &str) -> NaiveDate {
+        parse_date_from(input, today()).unwrap()
+    }
+
+    fn ymd(y: i32, m: u32, d: u32) -> NaiveDate {
+        NaiveDate::from_ymd_opt(y, m, d).unwrap()
+    }
+
+    #[test]
+    fn test_parse_absolute_iso_date() {
+        assert_eq!(parse("2026-08-01"), ymd(2026, 8, 1));
+        assert_eq!(parse("1999-12-31"), ymd(1999, 12, 31));
+    }
+
+    #[test]
+    fn test_parse_today_yesterday_tomorrow() {
+        assert_eq!(parse("today"), today());
+        assert_eq!(parse("t"), today());
+        assert_eq!(parse("yesterday"), ymd(2026, 8, 6));
+        assert_eq!(parse("y"), ymd(2026, 8, 6));
+        assert_eq!(parse("tomorrow"), ymd(2026, 8, 8));
+    }
+
+    #[test]
+    fn test_parse_day_and_week_offsets() {
+        assert_eq!(parse("-3d"), ymd(2026, 8, 4));
+        assert_eq!(parse("-2w"), ymd(2026, 7, 24));
+        assert_eq!(parse("-0d"), today());
+        assert_eq!(parse("+3d"), ymd(2026, 8, 10));
+        assert_eq!(parse("3d"), ymd(2026, 8, 10));
+    }
+
+    #[test]
+    fn test_parse_month_offset() {
+        assert_eq!(parse("-1m"), ymd(2026, 7, 7));
+        assert_eq!(parse("-12m"), ymd(2025, 8, 7));
+        assert_eq!(parse("+1m"), ymd(2026, 9, 7));
+    }
+
+    #[test]
+    fn test_month_offset_clamps_to_end_of_shorter_month() {
+        // March 31 minus one month has no March-31 equivalent in February.
+        let march31 = ymd(2026, 3, 31);
+        assert_eq!(parse_date_from("-1m", march31).unwrap(), ymd(2026, 2, 28));
+    }
+
+    #[test]
+    fn test_parse_weekday_returns_most_recent_past_occurrence() {
+        // today() is a Friday.
+        assert_eq!(parse("fri"), today());
+        assert_eq!(parse("friday"), today());
+        assert_eq!(parse("thu"), ymd(2026, 8, 6));
+        assert_eq!(parse("mon"), ymd(2026, 8, 3));
+        // Saturday is in the future, so it resolves to the previous Saturday.
+        assert_eq!(parse("sat"), ymd(2026, 8, 1));
+        assert_eq!(parse("sun"), ymd(2026, 8, 2));
+    }
+
+    #[test]
+    fn test_parse_is_case_insensitive_and_trims() {
+        assert_eq!(parse("  Yesterday  "), ymd(2026, 8, 6));
+        assert_eq!(parse("TODAY"), today());
+        assert_eq!(parse(" -3D "), ymd(2026, 8, 4));
+        assert_eq!(parse("Mon"), ymd(2026, 8, 3));
+    }
+
+    #[test]
+    fn test_parse_rejects_invalid_input() {
+        for bad in [
+            "",
+            "   ",
+            "not-a-date",
+            "2026-13-01",
+            "2026/08/01",
+            "-d",
+            "-3x",
+            "3",
+            "--3d",
+            "yester",
+        ] {
+            assert!(
+                parse_date_from(bad, today()).is_err(),
+                "expected {:?} to be rejected",
+                bad
+            );
+        }
+    }
+
+    #[test]
+    fn test_error_message_lists_accepted_forms() {
+        let err = parse_date_from("gibberish", today()).unwrap_err();
+        let message = err.to_string();
+        assert!(message.contains("gibberish"), "{}", message);
+        assert!(message.contains("YYYY-MM-DD"), "{}", message);
+        assert!(message.contains("yesterday"), "{}", message);
+    }
+
+    #[test]
+    fn test_parse_date_uses_current_date() {
+        assert_eq!(parse_date("today").unwrap(), Utc::now().date_naive());
+    }
+}

--- a/src/services/entity_resolution.rs
+++ b/src/services/entity_resolution.rs
@@ -20,20 +20,71 @@ use rusqlite::Connection;
 ///   overall add/edit operation, mirroring how a failed editor launch is a warning
 ///   rather than a hard error elsewhere in the CLI.
 pub fn resolve_or_create_entity(conn: &Connection, name: &str) -> Result<Option<i64>, ThoughtError> {
-    match EntitiesRepository::resolve(conn, name) {
-        Ok(Some(entity)) => Ok(entity.id),
-        Ok(None) => {
-            let entity = Entity::new(name.to_string());
-            Ok(Some(EntitiesRepository::find_or_create(conn, &entity)?))
-        }
-        Err(ThoughtError::AmbiguousAlias { alias, entities }) => {
-            eprintln!(
-                "Warning: '{}' matches multiple entities ({}); skipping link for this mention.",
-                alias,
-                entities.join(", ")
-            );
+    match resolve_entity(conn, name)? {
+        Resolution::Entity(id) => Ok(Some(id)),
+        Resolution::Ambiguous(ambiguous) => {
+            eprintln!("Warning: {}", ambiguous.describe());
             Ok(None)
         }
+    }
+}
+
+/// A mention that could not be linked because its alias is registered to more
+/// than one entity.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct AmbiguousMention {
+    /// The alias as written in the mention
+    pub alias: String,
+    /// Canonical names of every entity the alias could mean
+    pub candidates: Vec<String>,
+}
+
+impl AmbiguousMention {
+    /// One-line explanation, so every caller words this identically.
+    pub fn describe(&self) -> String {
+        format!(
+            "'{}' matches multiple entities ({}); skipping link for this mention.",
+            self.alias,
+            self.candidates.join(", ")
+        )
+    }
+}
+
+/// Outcome of resolving a single `[bracket]` mention.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Resolution {
+    /// Resolved (or created) to this entity ID
+    Entity(i64),
+    /// Left unlinked because the alias is ambiguous
+    Ambiguous(AmbiguousMention),
+}
+
+/// Resolve `name` to an entity ID, creating one if nothing matches, and *report*
+/// an ambiguous alias rather than printing about it.
+///
+/// [`resolve_or_create_entity`] is the plain-CLI wrapper that prints the warning
+/// to stderr. Callers that own the terminal — the interactive composer holds it in
+/// raw mode on the alternate screen — must use this instead: writing to stderr
+/// there lands on the same tty as the rendered frame and smears it, and because
+/// ratatui only redraws diffs the smear persists for the rest of the session.
+pub fn resolve_entity(conn: &Connection, name: &str) -> Result<Resolution, ThoughtError> {
+    match EntitiesRepository::resolve(conn, name) {
+        Ok(Some(entity)) => {
+            let id = match entity.id {
+                Some(id) => id,
+                // A resolved entity always has an ID; recreate rather than panic.
+                None => EntitiesRepository::find_or_create(conn, &entity)?,
+            };
+            Ok(Resolution::Entity(id))
+        }
+        Ok(None) => {
+            let entity = Entity::new(name.to_string());
+            Ok(Resolution::Entity(EntitiesRepository::find_or_create(conn, &entity)?))
+        }
+        Err(ThoughtError::AmbiguousAlias { alias, entities }) => Ok(Resolution::Ambiguous(AmbiguousMention {
+            alias,
+            candidates: entities,
+        })),
         Err(other) => Err(other),
     }
 }

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -4,3 +4,4 @@ pub mod description_formatter;
 pub mod entity_parser;
 pub mod entity_resolution;
 pub mod entity_styler;
+pub mod thought_writer;

--- a/src/services/mod.rs
+++ b/src/services/mod.rs
@@ -1,4 +1,5 @@
 pub mod color_mode;
+pub mod date_parser;
 pub mod description_formatter;
 pub mod entity_parser;
 pub mod entity_resolution;

--- a/src/services/thought_writer.rs
+++ b/src/services/thought_writer.rs
@@ -5,11 +5,24 @@
 
 use crate::errors::ThoughtError;
 use crate::models::thought::Thought;
+use crate::services::entity_resolution::{AmbiguousMention, Resolution};
 use crate::services::{entity_parser, entity_resolution};
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::thoughts_repository::ThoughtsRepository;
 use chrono::NaiveDate;
 use rusqlite::Connection;
+
+/// What a successful [`create_thought`] wrote.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Created {
+    /// ID of the new thought
+    pub id: i64,
+    /// Unique entity names extracted from the content, first-occurrence order.
+    /// Includes names that ended up ambiguous and therefore unlinked.
+    pub entities: Vec<String>,
+    /// Mentions left unlinked because their alias was ambiguous
+    pub ambiguous: Vec<AmbiguousMention>,
+}
 
 /// Persist a thought and link every entity mentioned in its content.
 ///
@@ -19,15 +32,9 @@ use rusqlite::Connection;
 /// `date` of `None` timestamps the thought with the current instant (matching
 /// `Thought::new`); `Some(date)` pins it to midnight UTC on that date.
 ///
-/// Returns the new thought's ID and the unique entity names extracted from its
-/// content, in first-occurrence order. Note that a mention resolving to an
-/// ambiguous alias is counted here but deliberately not linked - see
-/// [`entity_resolution::resolve_or_create_entity`].
-pub fn create_thought(
-    conn: &mut Connection,
-    content: &str,
-    date: Option<NaiveDate>,
-) -> Result<(i64, Vec<String>), ThoughtError> {
+/// Ambiguous mentions are *returned* rather than printed, so a caller that owns
+/// the terminal can surface them itself - see [`entity_resolution::resolve_entity`].
+pub fn create_thought(conn: &mut Connection, content: &str, date: Option<NaiveDate>) -> Result<Created, ThoughtError> {
     let thought = match date {
         Some(date) => {
             let datetime = date
@@ -41,18 +48,26 @@ pub fn create_thought(
 
     let tx = conn.transaction()?;
 
-    let thought_id = ThoughtsRepository::save(&tx, &thought)?;
+    let id = ThoughtsRepository::save(&tx, &thought)?;
 
-    let entity_names = entity_parser::extract_unique_entities(content);
-    for entity_name in &entity_names {
-        if let Some(entity_id) = entity_resolution::resolve_or_create_entity(&tx, entity_name)? {
-            EntitiesRepository::link_to_thought(&tx, entity_id, thought_id)?;
+    let entities = entity_parser::extract_unique_entities(content);
+    let mut ambiguous = Vec::new();
+    for entity_name in &entities {
+        match entity_resolution::resolve_entity(&tx, entity_name)? {
+            Resolution::Entity(entity_id) => {
+                EntitiesRepository::link_to_thought(&tx, entity_id, id)?;
+            }
+            Resolution::Ambiguous(mention) => ambiguous.push(mention),
         }
     }
 
     tx.commit()?;
 
-    Ok((thought_id, entity_names))
+    Ok(Created {
+        id,
+        entities,
+        ambiguous,
+    })
 }
 
 #[cfg(test)]
@@ -74,10 +89,11 @@ mod tests {
         let mut conn = setup();
         let before = chrono::Utc::now();
 
-        let (id, entities) = create_thought(&mut conn, "a plain thought", None).unwrap();
+        let created = create_thought(&mut conn, "a plain thought", None).unwrap();
 
-        assert!(entities.is_empty());
-        let saved = ThoughtsRepository::get_by_id(&conn, id).unwrap();
+        assert!(created.entities.is_empty());
+        assert!(created.ambiguous.is_empty());
+        let saved = ThoughtsRepository::get_by_id(&conn, created.id).unwrap();
         assert_eq!(saved.content, "a plain thought");
         assert!(saved.created_at >= before);
     }
@@ -87,9 +103,9 @@ mod tests {
         let mut conn = setup();
         let date = NaiveDate::from_ymd_opt(2026, 8, 1).unwrap();
 
-        let (id, _) = create_thought(&mut conn, "a backdated thought", Some(date)).unwrap();
+        let created = create_thought(&mut conn, "a backdated thought", Some(date)).unwrap();
 
-        let saved = ThoughtsRepository::get_by_id(&conn, id).unwrap();
+        let saved = ThoughtsRepository::get_by_id(&conn, created.id).unwrap();
         assert_eq!(saved.created_at, date.and_hms_opt(0, 0, 0).unwrap().and_utc());
     }
 
@@ -97,13 +113,13 @@ mod tests {
     fn test_create_thought_links_entity_mentions() {
         let mut conn = setup();
 
-        let (id, entities) = create_thought(&mut conn, "chatted with [Alice] about [Rust]", None).unwrap();
+        let created = create_thought(&mut conn, "chatted with [Alice] about [Rust]", None).unwrap();
 
-        assert_eq!(entities, vec!["Alice".to_string(), "Rust".to_string()]);
+        assert_eq!(created.entities, vec!["Alice".to_string(), "Rust".to_string()]);
         assert!(EntitiesRepository::find_by_name(&conn, "alice").unwrap().is_some());
         let linked = ThoughtsRepository::list_by_entity(&conn, "Alice").unwrap();
         assert_eq!(linked.len(), 1);
-        assert_eq!(linked[0].id, Some(id));
+        assert_eq!(linked[0].id, Some(created.id));
     }
 
     #[test]
@@ -123,9 +139,29 @@ mod tests {
     fn test_create_thought_deduplicates_repeated_mentions() {
         let mut conn = setup();
 
-        let (_, entities) = create_thought(&mut conn, "[Alice] and [alice] again", None).unwrap();
+        let created = create_thought(&mut conn, "[Alice] and [alice] again", None).unwrap();
 
-        assert_eq!(entities, vec!["Alice".to_string()]);
+        assert_eq!(created.entities, vec!["Alice".to_string()]);
+    }
+
+    #[test]
+    fn test_create_thought_reports_an_ambiguous_alias_instead_of_printing() {
+        let mut conn = setup();
+        let sarah = EntitiesRepository::find_or_create(&conn, &Entity::new("Sarah".to_string())).unwrap();
+        let john = EntitiesRepository::find_or_create(&conn, &Entity::new("John".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, sarah, "boss").unwrap();
+        EntityAliasesRepository::add_alias(&conn, john, "boss").unwrap();
+
+        let created = create_thought(&mut conn, "met [boss] today", None).unwrap();
+
+        // Returned, so a caller owning the terminal can render it itself rather
+        // than having stderr smear the frame.
+        assert_eq!(created.ambiguous.len(), 1);
+        assert_eq!(created.ambiguous[0].alias, "boss");
+        assert_eq!(created.ambiguous[0].candidates.len(), 2);
+        // Still saved, still unlinked, and no literal "boss" entity created.
+        assert!(ThoughtsRepository::get_by_id(&conn, created.id).is_ok());
+        assert!(EntitiesRepository::find_by_name(&conn, "boss").unwrap().is_none());
     }
 
     #[test]

--- a/src/services/thought_writer.rs
+++ b/src/services/thought_writer.rs
@@ -1,0 +1,156 @@
+//! Thought creation service - persists a new thought and links its entity mentions.
+//!
+//! Shared by `wet add` and the interactive composer so both take exactly the same
+//! path. Like `entity_resolution`, this service touches the database directly.
+
+use crate::errors::ThoughtError;
+use crate::models::thought::Thought;
+use crate::services::{entity_parser, entity_resolution};
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::thoughts_repository::ThoughtsRepository;
+use chrono::NaiveDate;
+use rusqlite::Connection;
+
+/// Persist a thought and link every entity mentioned in its content.
+///
+/// The whole operation runs in a single transaction: if entity resolution or
+/// linking fails, the thought itself is not left behind.
+///
+/// `date` of `None` timestamps the thought with the current instant (matching
+/// `Thought::new`); `Some(date)` pins it to midnight UTC on that date.
+///
+/// Returns the new thought's ID and the unique entity names extracted from its
+/// content, in first-occurrence order. Note that a mention resolving to an
+/// ambiguous alias is counted here but deliberately not linked - see
+/// [`entity_resolution::resolve_or_create_entity`].
+pub fn create_thought(
+    conn: &mut Connection,
+    content: &str,
+    date: Option<NaiveDate>,
+) -> Result<(i64, Vec<String>), ThoughtError> {
+    let thought = match date {
+        Some(date) => {
+            let datetime = date
+                .and_hms_opt(0, 0, 0)
+                .expect("midnight is a valid time for any date")
+                .and_utc();
+            Thought::new_with_date(content.to_string(), datetime)?
+        }
+        None => Thought::new(content.to_string())?,
+    };
+
+    let tx = conn.transaction()?;
+
+    let thought_id = ThoughtsRepository::save(&tx, &thought)?;
+
+    let entity_names = entity_parser::extract_unique_entities(content);
+    for entity_name in &entity_names {
+        if let Some(entity_id) = entity_resolution::resolve_or_create_entity(&tx, entity_name)? {
+            EntitiesRepository::link_to_thought(&tx, entity_id, thought_id)?;
+        }
+    }
+
+    tx.commit()?;
+
+    Ok((thought_id, entity_names))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::models::entity::Entity;
+    use crate::storage::connection::get_memory_connection;
+    use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+    use crate::storage::migrations::run_migrations;
+
+    fn setup() -> Connection {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+        conn
+    }
+
+    #[test]
+    fn test_create_thought_without_date_uses_now() {
+        let mut conn = setup();
+        let before = chrono::Utc::now();
+
+        let (id, entities) = create_thought(&mut conn, "a plain thought", None).unwrap();
+
+        assert!(entities.is_empty());
+        let saved = ThoughtsRepository::get_by_id(&conn, id).unwrap();
+        assert_eq!(saved.content, "a plain thought");
+        assert!(saved.created_at >= before);
+    }
+
+    #[test]
+    fn test_create_thought_with_date_pins_to_midnight() {
+        let mut conn = setup();
+        let date = NaiveDate::from_ymd_opt(2026, 8, 1).unwrap();
+
+        let (id, _) = create_thought(&mut conn, "a backdated thought", Some(date)).unwrap();
+
+        let saved = ThoughtsRepository::get_by_id(&conn, id).unwrap();
+        assert_eq!(saved.created_at, date.and_hms_opt(0, 0, 0).unwrap().and_utc());
+    }
+
+    #[test]
+    fn test_create_thought_links_entity_mentions() {
+        let mut conn = setup();
+
+        let (id, entities) = create_thought(&mut conn, "chatted with [Alice] about [Rust]", None).unwrap();
+
+        assert_eq!(entities, vec!["Alice".to_string(), "Rust".to_string()]);
+        assert!(EntitiesRepository::find_by_name(&conn, "alice").unwrap().is_some());
+        let linked = ThoughtsRepository::list_by_entity(&conn, "Alice").unwrap();
+        assert_eq!(linked.len(), 1);
+        assert_eq!(linked[0].id, Some(id));
+    }
+
+    #[test]
+    fn test_create_thought_resolves_alias_to_existing_entity() {
+        let mut conn = setup();
+        let alice_id = EntitiesRepository::find_or_create(&conn, &Entity::new("Alice".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, alice_id, "alicia").unwrap();
+
+        create_thought(&mut conn, "paired with [al](alicia)", None).unwrap();
+
+        // The alias resolved to the existing entity; no duplicate "alicia" created.
+        assert!(EntitiesRepository::find_by_name(&conn, "alicia").unwrap().is_none());
+        assert_eq!(ThoughtsRepository::list_by_entity(&conn, "Alice").unwrap().len(), 1);
+    }
+
+    #[test]
+    fn test_create_thought_deduplicates_repeated_mentions() {
+        let mut conn = setup();
+
+        let (_, entities) = create_thought(&mut conn, "[Alice] and [alice] again", None).unwrap();
+
+        assert_eq!(entities, vec!["Alice".to_string()]);
+    }
+
+    #[test]
+    fn test_create_thought_rejects_empty_content_without_writing() {
+        let mut conn = setup();
+
+        let result = create_thought(&mut conn, "   ", None);
+
+        assert!(matches!(result, Err(ThoughtError::EmptyContent)));
+        assert!(ThoughtsRepository::list_all(&conn).unwrap().is_empty());
+    }
+
+    #[test]
+    fn test_create_thought_rolls_back_when_linking_fails() {
+        let mut conn = setup();
+        // Drop the junction table so linking fails partway through, after the
+        // thought row has already been inserted inside the transaction.
+        conn.execute("DROP TABLE thought_entities", []).unwrap();
+
+        let result = create_thought(&mut conn, "mentions [Alice]", None);
+
+        assert!(result.is_err());
+        assert!(
+            ThoughtsRepository::list_all(&conn).unwrap().is_empty(),
+            "the thought should not survive a failed link"
+        );
+    }
+}

--- a/src/tui/compose/input.rs
+++ b/src/tui/compose/input.rs
@@ -1,0 +1,780 @@
+//! Key event handling for the interactive composer.
+//!
+//! Two key maps: one while the entity whisperer popup is open, one while it is
+//! closed. See [`handle_key_event`].
+
+use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+use tui_input::backend::crossterm::EventHandler;
+
+use super::ComposeApp;
+use super::state::{Field, Slot, Whisperer};
+use crate::tui::fuzzy;
+
+/// Handle a key event and update composer state.
+///
+/// While the whisperer is open it takes priority, capturing navigation and
+/// acceptance keys; everything else falls through to the focused text field.
+pub fn handle_key_event(app: &mut ComposeApp, key: KeyEvent) {
+    // Ctrl-C always leaves, whatever is on screen.
+    if key.modifiers.contains(KeyModifiers::CONTROL) && matches!(key.code, KeyCode::Char('c')) {
+        app.should_quit = true;
+        return;
+    }
+
+    // Alt-arrows nudge the date from wherever you are, so a one-day correction
+    // costs no field switch. `tui_input` leaves these unbound (it takes the Ctrl
+    // variants for word movement), so nothing is clobbered.
+    if key.modifiers.contains(KeyModifiers::ALT) {
+        match key.code {
+            KeyCode::Left => return app.nudge_date(-1),
+            KeyCode::Right => return app.nudge_date(1),
+            _ => {}
+        }
+    }
+
+    if app.whisperer.is_some() {
+        handle_whisperer_key(app, key);
+    } else {
+        handle_field_key(app, key);
+    }
+}
+
+/// Key handling while the entity completion popup is open.
+fn handle_whisperer_key(app: &mut ComposeApp, key: KeyEvent) {
+    let has_matches = app.whisperer.as_ref().is_some_and(|w| w.selected_candidate().is_some());
+
+    match key.code {
+        KeyCode::Up => {
+            if let Some(whisperer) = app.whisperer.as_mut() {
+                whisperer.select_previous();
+            }
+        }
+        KeyCode::Down => {
+            if let Some(whisperer) = app.whisperer.as_mut() {
+                whisperer.select_next();
+            }
+        }
+        KeyCode::Esc => {
+            // Dismiss the popup but keep whatever was typed.
+            app.whisperer = None;
+        }
+        KeyCode::Tab | KeyCode::Enter if has_matches => {
+            accept_completion(app);
+        }
+        // With nothing to complete, the popup is just noise: dismiss it and let
+        // the key do what it normally would.
+        KeyCode::Tab | KeyCode::Enter => {
+            app.whisperer = None;
+            handle_field_key(app, key);
+        }
+        _ => {
+            app.content.handle_event(&ratatui::crossterm::event::Event::Key(key));
+            recompute_whisperer(app, key);
+        }
+    }
+}
+
+/// Key handling while no popup is open.
+fn handle_field_key(app: &mut ComposeApp, key: KeyEvent) {
+    match key.code {
+        KeyCode::Esc => app.should_quit = true,
+        KeyCode::Tab | KeyCode::BackTab => app.focus = app.focus.toggled(),
+        KeyCode::Enter => app.save(),
+        _ => {
+            let field = match app.focus {
+                Field::Date => &mut app.date,
+                Field::Content => &mut app.content,
+            };
+            field.handle_event(&ratatui::crossterm::event::Event::Key(key));
+            if app.focus == Field::Content {
+                recompute_whisperer(app, key);
+            }
+        }
+    }
+}
+
+/// Replace the partial reference in the content with the selected candidate's
+/// text, and place the cursor just past it.
+///
+/// A trailing space is appended so typing can continue straight away — see
+/// [`needs_trailing_space`] for when that is skipped.
+fn accept_completion(app: &mut ComposeApp) {
+    let Some(whisperer) = app.whisperer.as_ref() else {
+        return;
+    };
+    let Some(candidate_idx) = whisperer.selected_candidate() else {
+        return;
+    };
+    let mut insertion = app.candidates[candidate_idx].insertion(whisperer.slot);
+    let open_at = whisperer.open_at;
+    let cursor = app.content.cursor();
+
+    let chars: Vec<char> = app.content.value().chars().collect();
+    let prefix: String = chars[..open_at.min(chars.len())].iter().collect();
+    let suffix: String = chars[cursor.min(chars.len())..].iter().collect();
+
+    if needs_trailing_space(&suffix) {
+        insertion.push(' ');
+    }
+    let new_cursor = open_at + insertion.chars().count();
+
+    app.content = tui_input::Input::new(format!("{}{}{}", prefix, insertion, suffix)).with_cursor(new_cursor);
+    app.whisperer = None;
+}
+
+/// Whether an accepted completion should be followed by a space.
+///
+/// Yes at the end of the line, which is the usual case. Skipped when the text
+/// that follows already starts with whitespace (it would double up) or with
+/// punctuation that should hug the reference — `[Alice].`, `[Alice]'s`, `[Alice],`.
+fn needs_trailing_space(suffix: &str) -> bool {
+    match suffix.chars().next() {
+        None => true,
+        Some(next) => {
+            !next.is_whitespace() && !matches!(next, '.' | ',' | ';' | ':' | '!' | '?' | ')' | ']' | '}' | '\'' | '"')
+        }
+    }
+}
+
+/// Open, update, or close the whisperer after a content keystroke.
+///
+/// Two triggers:
+///
+/// - `[` opens the popup on the reference's display slot, anchored at that bracket.
+/// - `(` typed straight after a `]` opens it on the target slot, so a reference whose
+///   wording was written by hand — `[my boss](…` — can still complete its entity.
+///
+/// While open, the query is the text between the opening bracket and the cursor. The
+/// popup closes if the cursor moves back to or past that bracket, if the bracket is
+/// edited away, or if the query grows the slot's closing character.
+fn recompute_whisperer(app: &mut ComposeApp, key: KeyEvent) {
+    let cursor = app.content.cursor();
+
+    if let Some(slot) = opening_slot(app, key, cursor) {
+        // The bracket just inserted sits immediately before the cursor.
+        app.whisperer = Some(Whisperer {
+            open_at: cursor.saturating_sub(1),
+            slot,
+            matches: fuzzy::match_indices("", &app.candidate_labels()),
+            selected: 0,
+        });
+        return;
+    }
+
+    let Some((open_at, slot)) = app.whisperer.as_ref().map(|w| (w.open_at, w.slot)) else {
+        return;
+    };
+
+    // Cursor moved back to or before the opening bracket - the popup no longer
+    // describes what is being typed.
+    if cursor <= open_at {
+        app.whisperer = None;
+        return;
+    }
+
+    let chars: Vec<char> = app.content.value().chars().collect();
+    // The bracket was edited away (e.g. the whole field was cleared).
+    if chars.get(open_at) != Some(&slot.opening_char()) {
+        app.whisperer = None;
+        return;
+    }
+
+    let query: String = chars[open_at + 1..cursor.min(chars.len())].iter().collect();
+    if query.contains(slot.closing_char()) {
+        app.whisperer = None;
+        return;
+    }
+
+    let matches = fuzzy::match_indices(&query, &app.candidate_labels());
+    if let Some(whisperer) = app.whisperer.as_mut() {
+        whisperer.matches = matches;
+        whisperer.selected = 0;
+    }
+}
+
+/// The slot a just-typed character opens a popup for, if any.
+///
+/// `(` only counts when it directly follows a `]`, so ordinary parenthetical prose
+/// never triggers the whisperer.
+fn opening_slot(app: &ComposeApp, key: KeyEvent, cursor: usize) -> Option<Slot> {
+    match key.code {
+        KeyCode::Char('[') => Some(Slot::Display),
+        KeyCode::Char('(') => {
+            let preceding = app.content.value().chars().nth(cursor.checked_sub(2)?)?;
+            (preceding == ']').then_some(Slot::Target)
+        }
+        _ => None,
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::Status;
+    use super::super::test_support::{seeded_app, type_text};
+    use super::*;
+
+    fn key(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::NONE)
+    }
+
+    /// Labels of the candidates currently offered by the whisperer.
+    fn offered(app: &ComposeApp) -> Vec<String> {
+        app.whisperer
+            .as_ref()
+            .map(|w| w.matches.iter().map(|&i| app.candidates[i].label.clone()).collect())
+            .unwrap_or_default()
+    }
+
+    #[test]
+    fn test_content_open_bracket_opens_whisperer() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "met [");
+
+        let whisperer = app.whisperer.as_ref().expect("whisperer should be open");
+        assert_eq!(whisperer.open_at, 4);
+        // With an empty query every candidate is offered.
+        assert_eq!(whisperer.matches.len(), app.candidates.len());
+    }
+
+    #[test]
+    fn test_whisperer_typing_narrows_matches() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "[ali");
+
+        let offered = offered(&app);
+        assert!(offered.contains(&"Alice".to_string()));
+        assert!(offered.contains(&"alicia".to_string()));
+        assert!(!offered.contains(&"Bob".to_string()));
+    }
+
+    #[test]
+    fn test_whisperer_tab_inserts_canonical_reference() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [alic");
+        // Alice outranks the alias for this query.
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [Alice] ");
+        assert_eq!(app.content.cursor(), 12, "cursor sits after the appended space");
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_whisperer_enter_accepts_instead_of_saving() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[bob");
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.content.value(), "[Bob] ");
+        assert_eq!(app.saved_count, 0, "Enter should complete, not save");
+    }
+
+    #[test]
+    fn test_whisperer_selecting_alias_inserts_aliased_reference() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[alicia");
+        // Exact alias text ranks the alias first.
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "[alicia](Alice) ");
+    }
+
+    #[test]
+    fn test_whisperer_down_moves_selection() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+        let first = app.whisperer.as_ref().unwrap().selected_candidate();
+
+        handle_key_event(&mut app, key(KeyCode::Down));
+        let second = app.whisperer.as_ref().unwrap().selected_candidate();
+
+        assert_ne!(first, second);
+    }
+
+    #[test]
+    fn test_whisperer_accepts_the_highlighted_candidate() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+        handle_key_event(&mut app, key(KeyCode::Down));
+        let expected = {
+            let idx = app.whisperer.as_ref().unwrap().selected_candidate().unwrap();
+            app.candidates[idx].insertion(Slot::Display)
+        };
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), format!("{} ", expected));
+    }
+
+    #[test]
+    fn test_completion_lets_typing_continue_without_a_manual_space() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [alic");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        type_text(&mut app, "at the standup");
+
+        assert_eq!(app.content.value(), "met [Alice] at the standup");
+    }
+
+    #[test]
+    fn test_completion_does_not_double_an_existing_space() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met  today");
+        for _ in 0..6 {
+            handle_key_event(&mut app, key(KeyCode::Left));
+        }
+        type_text(&mut app, "[bo");
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [Bob] today");
+    }
+
+    #[test]
+    fn test_completion_does_not_space_off_following_punctuation() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met .");
+        handle_key_event(&mut app, key(KeyCode::Left));
+        type_text(&mut app, "[bo");
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [Bob].");
+    }
+
+    #[test]
+    fn test_completion_does_not_space_off_a_following_apostrophe() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met 's laptop");
+        for _ in 0..9 {
+            handle_key_event(&mut app, key(KeyCode::Left));
+        }
+        type_text(&mut app, "[bo");
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [Bob]'s laptop");
+    }
+
+    #[test]
+    fn test_target_completion_also_appends_a_space() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [my boss](ali");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        type_text(&mut app, "today");
+
+        assert_eq!(app.content.value(), "met [my boss](Alice) today");
+    }
+
+    #[test]
+    fn test_trailing_space_is_trimmed_before_saving() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [alic");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+        assert_eq!(app.content.value(), "met [Alice] ", "the space is there while editing");
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.saved_count, 1);
+        let saved = crate::storage::thoughts_repository::ThoughtsRepository::list_all(&app.conn).unwrap();
+        assert_eq!(saved[0].content, "met [Alice]", "no trailing space reaches storage");
+    }
+
+    #[test]
+    fn test_whisperer_closing_bracket_dismisses_popup() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "[Carol]");
+
+        assert!(app.whisperer.is_none());
+        assert_eq!(app.content.value(), "[Carol]");
+    }
+
+    #[test]
+    fn test_whisperer_backspacing_past_bracket_dismisses_popup() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[al");
+
+        handle_key_event(&mut app, key(KeyCode::Backspace));
+        assert!(app.whisperer.is_some(), "still inside the reference");
+        handle_key_event(&mut app, key(KeyCode::Backspace));
+        assert!(app.whisperer.is_some(), "cursor is still just past the bracket");
+        handle_key_event(&mut app, key(KeyCode::Backspace));
+
+        assert!(app.whisperer.is_none(), "the bracket itself is gone");
+        assert_eq!(app.content.value(), "");
+    }
+
+    #[test]
+    fn test_whisperer_cursor_left_past_bracket_dismisses_popup() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[al");
+
+        handle_key_event(&mut app, key(KeyCode::Left));
+        handle_key_event(&mut app, key(KeyCode::Left));
+        assert!(app.whisperer.is_some());
+        handle_key_event(&mut app, key(KeyCode::Left));
+
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_whisperer_esc_dismisses_popup_without_quitting() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.whisperer.is_none());
+        assert!(!app.should_quit);
+        assert_eq!(app.content.value(), "[ali", "typed text is preserved");
+    }
+
+    #[test]
+    fn test_whisperer_with_no_matches_lets_enter_save() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[zzzz");
+        assert!(app.whisperer.as_ref().unwrap().matches.is_empty());
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert!(app.whisperer.is_none());
+        assert_eq!(app.saved_count, 1, "free-form entity names are still allowed");
+    }
+
+    #[test]
+    fn test_open_paren_after_bracket_opens_target_whisperer() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "met [my boss](");
+
+        let whisperer = app.whisperer.as_ref().expect("whisperer should be open");
+        assert_eq!(whisperer.slot, Slot::Target);
+        assert_eq!(whisperer.open_at, 13);
+        assert_eq!(whisperer.matches.len(), app.candidates.len());
+    }
+
+    #[test]
+    fn test_target_whisperer_completes_the_link_keeping_the_wording() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "met [my boss](ali");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [my boss](Alice) ");
+        assert_eq!(app.content.cursor(), 21, "cursor lands past the appended space");
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_target_whisperer_resolves_an_alias_to_its_canonical_name() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [my boss](alicia");
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        // The display wording is already written, so picking the alias contributes
+        // only the entity it points at - never `[my boss](alicia)`.
+        assert_eq!(app.content.value(), "met [my boss](Alice) ");
+    }
+
+    #[test]
+    fn test_target_whisperer_narrows_on_the_target_query() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "[my boss](bo");
+
+        let offered = offered(&app);
+        assert_eq!(offered, vec!["Bob".to_string()]);
+    }
+
+    #[test]
+    fn test_target_whisperer_closes_on_its_own_closing_paren() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "[my boss](Alice)");
+
+        assert!(app.whisperer.is_none());
+        assert_eq!(app.content.value(), "[my boss](Alice)");
+    }
+
+    #[test]
+    fn test_target_whisperer_ignores_a_closing_bracket() {
+        let mut app = seeded_app();
+
+        // `]` ends the display slot, not the target slot - it must not close this popup.
+        type_text(&mut app, "[my boss](al]");
+
+        assert!(app.whisperer.is_some());
+    }
+
+    #[test]
+    fn test_paren_in_ordinary_prose_does_not_open_the_whisperer() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "met Alice (by the way");
+
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_paren_at_start_of_content_does_not_open_the_whisperer() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "(");
+
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_target_whisperer_dismissed_by_esc_keeps_typed_text() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[my boss](ali");
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.whisperer.is_none());
+        assert!(!app.should_quit);
+        assert_eq!(app.content.value(), "[my boss](ali");
+    }
+
+    #[test]
+    fn test_completed_free_form_link_saves_against_the_existing_entity() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [my boss](ali");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        // The target resolves to a known entity, so nothing new is created.
+        assert!(app.new_entity_mentions().is_empty());
+    }
+
+    #[test]
+    fn test_whisperer_reopens_on_a_second_bracket() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[Alice] and [bo");
+
+        let whisperer = app.whisperer.as_ref().expect("whisperer should be open");
+        assert_eq!(whisperer.open_at, 12);
+        assert_eq!(offered(&app), vec!["Bob".to_string()]);
+    }
+
+    #[test]
+    fn test_field_tab_switches_focus() {
+        let mut app = seeded_app();
+        assert_eq!(app.focus, Field::Content);
+
+        handle_key_event(&mut app, key(KeyCode::Tab));
+        assert_eq!(app.focus, Field::Date);
+
+        handle_key_event(&mut app, key(KeyCode::BackTab));
+        assert_eq!(app.focus, Field::Content);
+    }
+
+    #[test]
+    fn test_field_typing_goes_to_the_focused_field() {
+        let mut app = seeded_app();
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        type_text(&mut app, "yesterday");
+
+        assert_eq!(app.date.value(), "yesterday");
+        assert_eq!(app.content.value(), "");
+    }
+
+    #[test]
+    fn test_bracket_in_date_field_does_not_open_whisperer() {
+        let mut app = seeded_app();
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        type_text(&mut app, "[");
+
+        assert!(app.whisperer.is_none());
+    }
+
+    #[test]
+    fn test_field_enter_saves_and_clears_content() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought");
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.saved_count, 1);
+        assert_eq!(app.content.value(), "");
+    }
+
+    #[test]
+    fn test_field_enter_from_date_field_also_saves() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.saved_count, 1);
+    }
+
+    #[test]
+    fn test_field_enter_with_invalid_date_does_not_save() {
+        let mut app = seeded_app();
+        handle_key_event(&mut app, key(KeyCode::Tab));
+        type_text(&mut app, "nonsense");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+        type_text(&mut app, "a thought");
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+
+        assert_eq!(app.saved_count, 0);
+        assert!(matches!(app.status, Some(Status::Error(_))));
+        assert_eq!(app.content.value(), "a thought");
+    }
+
+    /// Alt-arrow, as the terminal delivers it.
+    fn alt(code: KeyCode) -> KeyEvent {
+        KeyEvent::new(code, KeyModifiers::ALT)
+    }
+
+    fn days_from_today(offset: i64) -> String {
+        let today = chrono::Utc::now().date_naive();
+        let magnitude = chrono::Days::new(offset.unsigned_abs());
+        let date = if offset < 0 {
+            today.checked_sub_days(magnitude).unwrap()
+        } else {
+            today.checked_add_days(magnitude).unwrap()
+        };
+        date.format("%Y-%m-%d").to_string()
+    }
+
+    #[test]
+    fn test_alt_left_shifts_the_date_back_without_leaving_content() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [Alice]");
+
+        handle_key_event(&mut app, alt(KeyCode::Left));
+
+        assert_eq!(app.date.value(), days_from_today(-1));
+        assert_eq!(app.focus, Field::Content, "focus must not move");
+        assert_eq!(app.content.value(), "met [Alice]", "content is untouched");
+    }
+
+    #[test]
+    fn test_alt_right_shifts_the_date_forward() {
+        let mut app = seeded_app();
+
+        handle_key_event(&mut app, alt(KeyCode::Right));
+
+        assert_eq!(app.date.value(), days_from_today(1));
+    }
+
+    #[test]
+    fn test_alt_arrows_accumulate() {
+        let mut app = seeded_app();
+
+        for _ in 0..3 {
+            handle_key_event(&mut app, alt(KeyCode::Left));
+        }
+
+        assert_eq!(app.date.value(), days_from_today(-3));
+    }
+
+    #[test]
+    fn test_alt_arrow_resolves_a_relative_date_to_an_absolute_one() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("yesterday".to_string());
+
+        handle_key_event(&mut app, alt(KeyCode::Left));
+
+        assert_eq!(app.date.value(), days_from_today(-2));
+    }
+
+    #[test]
+    fn test_alt_arrow_shifts_an_absolute_date() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("2026-03-01".to_string());
+
+        handle_key_event(&mut app, alt(KeyCode::Left));
+
+        assert_eq!(app.date.value(), "2026-02-28");
+    }
+
+    #[test]
+    fn test_alt_arrow_leaves_an_unparseable_date_alone() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("nonsen".to_string());
+
+        handle_key_event(&mut app, alt(KeyCode::Left));
+
+        assert_eq!(app.date.value(), "nonsen", "must not overwrite a half-typed date");
+    }
+
+    #[test]
+    fn test_alt_arrows_work_while_the_whisperer_is_open() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [ali");
+
+        handle_key_event(&mut app, alt(KeyCode::Left));
+
+        assert_eq!(app.date.value(), days_from_today(-1));
+        assert!(app.whisperer.is_some(), "the popup should survive a date nudge");
+    }
+
+    #[test]
+    fn test_plain_arrows_still_move_the_cursor() {
+        let mut app = seeded_app();
+        type_text(&mut app, "abc");
+
+        handle_key_event(&mut app, key(KeyCode::Left));
+
+        assert_eq!(app.content.cursor(), 2);
+        assert_eq!(app.date.value(), "", "an unmodified arrow must not touch the date");
+    }
+
+    #[test]
+    fn test_ctrl_arrows_still_move_by_word() {
+        let mut app = seeded_app();
+        type_text(&mut app, "one two");
+
+        handle_key_event(&mut app, KeyEvent::new(KeyCode::Left, KeyModifiers::CONTROL));
+
+        assert_eq!(app.content.cursor(), 4, "Ctrl+Left is tui-input's word movement");
+        assert_eq!(app.date.value(), "");
+    }
+
+    #[test]
+    fn test_field_esc_quits() {
+        let mut app = seeded_app();
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_ctrl_c_quits_even_with_whisperer_open() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+
+        handle_key_event(&mut app, KeyEvent::new(KeyCode::Char('c'), KeyModifiers::CONTROL));
+
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_completion_inserts_mid_line_keeping_the_suffix() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met  today");
+        // Move the cursor back between "met " and " today".
+        for _ in 0..6 {
+            handle_key_event(&mut app, key(KeyCode::Left));
+        }
+        type_text(&mut app, "[bo");
+        handle_key_event(&mut app, key(KeyCode::Tab));
+
+        assert_eq!(app.content.value(), "met [Bob] today");
+        assert_eq!(app.content.cursor(), 9);
+    }
+}

--- a/src/tui/compose/input.rs
+++ b/src/tui/compose/input.rs
@@ -6,8 +6,8 @@
 use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
 use tui_input::backend::crossterm::EventHandler;
 
-use super::ComposeApp;
 use super::state::{Field, Slot, Whisperer};
+use super::{ComposeApp, Status};
 use crate::tui::fuzzy;
 
 /// Handle a key event and update composer state.
@@ -76,8 +76,24 @@ fn handle_whisperer_key(app: &mut ComposeApp, key: KeyEvent) {
 
 /// Key handling while no popup is open.
 fn handle_field_key(app: &mut ComposeApp, key: KeyEvent) {
+    // Any key other than a second Esc disarms a pending discard.
+    if !matches!(key.code, KeyCode::Esc) {
+        app.pending_quit = false;
+    }
+
     match key.code {
-        KeyCode::Esc => app.should_quit = true,
+        // Leaving with an unsaved thought is the one destructive dismissal in the
+        // composer, so it takes a confirmation the others do not.
+        KeyCode::Esc => {
+            if app.content.value().trim().is_empty() || app.pending_quit {
+                app.should_quit = true;
+            } else {
+                app.pending_quit = true;
+                app.status = Some(Status::Error(
+                    "Unsaved thought. Press Esc again to discard it, or Enter to save.".to_string(),
+                ));
+            }
+        }
         KeyCode::Tab | KeyCode::BackTab => app.focus = app.focus.toggled(),
         KeyCode::Enter => app.save(),
         _ => {
@@ -155,7 +171,7 @@ fn recompute_whisperer(app: &mut ComposeApp, key: KeyEvent) {
         app.whisperer = Some(Whisperer {
             open_at: cursor.saturating_sub(1),
             slot,
-            matches: fuzzy::match_indices("", &app.candidate_labels()),
+            matches: matching_candidates(app, "", slot),
             selected: 0,
         });
         return;
@@ -185,11 +201,21 @@ fn recompute_whisperer(app: &mut ComposeApp, key: KeyEvent) {
         return;
     }
 
-    let matches = fuzzy::match_indices(&query, &app.candidate_labels());
+    let matches = matching_candidates(app, &query, slot);
     if let Some(whisperer) = app.whisperer.as_mut() {
         whisperer.matches = matches;
         whisperer.selected = 0;
     }
+}
+
+/// Candidate indices matching `query`, restricted to those valid in `slot`.
+fn matching_candidates(app: &ComposeApp, query: &str, slot: Slot) -> Vec<usize> {
+    let selectable = app.selectable_candidates(slot);
+    let labels: Vec<&str> = selectable.iter().map(|&i| app.candidates[i].label.as_str()).collect();
+    fuzzy::match_indices(query, &labels)
+        .into_iter()
+        .map(|matched| selectable[matched])
+        .collect()
 }
 
 /// The slot a just-typed character opens a popup for, if any.
@@ -745,12 +771,108 @@ mod tests {
     }
 
     #[test]
-    fn test_field_esc_quits() {
+    fn test_field_esc_quits_when_nothing_is_typed() {
         let mut app = seeded_app();
 
         handle_key_event(&mut app, key(KeyCode::Esc));
 
         assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_esc_with_unsaved_content_asks_before_discarding() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought worth keeping");
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(!app.should_quit, "one Esc must not throw away typed text");
+        assert!(app.pending_quit);
+        assert!(matches!(app.status, Some(Status::Error(ref m)) if m.contains("Esc again")));
+        assert_eq!(app.content.value(), "a thought worth keeping");
+    }
+
+    #[test]
+    fn test_second_esc_discards_and_quits() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought");
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.should_quit);
+    }
+
+    #[test]
+    fn test_typing_after_esc_disarms_the_discard() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought");
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        type_text(&mut app, "!");
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(!app.should_quit, "the confirmation must be re-armed after an edit");
+        assert!(app.pending_quit);
+    }
+
+    #[test]
+    fn test_saving_clears_the_pending_discard() {
+        let mut app = seeded_app();
+        type_text(&mut app, "a thought");
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        handle_key_event(&mut app, key(KeyCode::Enter));
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.should_quit, "content is empty after a save, so Esc just leaves");
+        assert_eq!(app.saved_count, 1);
+    }
+
+    #[test]
+    fn test_whisperer_esc_does_not_arm_a_discard() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [ali");
+
+        handle_key_event(&mut app, key(KeyCode::Esc));
+
+        assert!(app.whisperer.is_none(), "the popup closes");
+        assert!(!app.pending_quit, "closing the popup is not a quit attempt");
+        assert!(!app.should_quit);
+    }
+
+    #[test]
+    fn test_target_slot_hides_entities_whose_name_has_parentheses() {
+        let mut app = seeded_app();
+        app.candidates.push(super::super::state::Candidate {
+            label: "Wetware (project)".to_string(),
+            canonical: "Wetware (project)".to_string(),
+            is_alias: false,
+            description: None,
+        });
+
+        // Display slot can express it: `[Wetware (project)]` parses fine.
+        type_text(&mut app, "[wetware");
+        assert!(offered(&app).contains(&"Wetware (project)".to_string()));
+
+        // Target slot cannot: `](Wetware (project))` misparses, so do not offer it.
+        app.content = tui_input::Input::default();
+        app.whisperer = None;
+        type_text(&mut app, "[my thing](wetware");
+        assert!(
+            !offered(&app).contains(&"Wetware (project)".to_string()),
+            "offered: {:?}",
+            offered(&app)
+        );
+    }
+
+    #[test]
+    fn test_target_slot_still_offers_ordinary_entities() {
+        let mut app = seeded_app();
+
+        type_text(&mut app, "[my boss](ali");
+
+        assert!(offered(&app).contains(&"Alice".to_string()));
     }
 
     #[test]

--- a/src/tui/compose/mod.rs
+++ b/src/tui/compose/mod.rs
@@ -25,7 +25,7 @@ use crate::services::{date_parser, entity_parser, thought_writer};
 use crate::storage::entities_repository::EntitiesRepository;
 use crate::storage::entity_aliases_repository::EntityAliasesRepository;
 
-use state::{Candidate, Field, Whisperer};
+use state::{Candidate, Field, Slot, Whisperer};
 
 /// Outcome of the last save attempt, shown in the composer's status line.
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -60,6 +60,8 @@ pub struct ComposeApp {
     pub saved_count: usize,
     /// Set when the user asks to leave
     pub should_quit: bool,
+    /// An `Esc` on a non-empty thought is armed but not yet confirmed
+    pub pending_quit: bool,
     conn: Connection,
 }
 
@@ -78,6 +80,7 @@ impl ComposeApp {
             status: None,
             saved_count: 0,
             should_quit: false,
+            pending_quit: false,
             conn,
         };
         app.reload_candidates()?;
@@ -122,6 +125,23 @@ impl ComposeApp {
     /// The labels of all candidates, in order, for fuzzy matching.
     pub fn candidate_labels(&self) -> Vec<&str> {
         self.candidates.iter().map(|c| c.label.as_str()).collect()
+    }
+
+    /// Indices of the candidates that can legally be accepted in `slot`.
+    ///
+    /// A target is written as `](Name)`, and `entity_parser`'s target group cannot
+    /// span a nested paren, so an entity whose canonical name contains `(` or `)`
+    /// has no valid target form: accepting it would silently degrade the reference
+    /// to the traditional one and create an entity named after the display text.
+    /// Such entities are still reachable through the display slot, which tolerates
+    /// parens, so they are simply not offered here.
+    pub fn selectable_candidates(&self, slot: Slot) -> Vec<usize> {
+        (0..self.candidates.len())
+            .filter(|&i| match slot {
+                Slot::Display => true,
+                Slot::Target => !self.candidates[i].canonical.contains(['(', ')']),
+            })
+            .collect()
     }
 
     /// Resolve the date field to a calendar date.
@@ -186,13 +206,21 @@ impl ComposeApp {
         // Trimmed so the space appended after a completion never reaches storage.
         let content = self.content.value().trim().to_string();
         match thought_writer::create_thought(&mut self.conn, &content, date) {
-            Ok((id, entities)) => {
+            Ok(created) => {
                 self.content.reset();
                 self.whisperer = None;
+                self.pending_quit = false;
                 self.saved_count += 1;
-                self.status = Some(Status::Saved {
-                    id,
-                    entities: entities.len(),
+                // Ambiguous mentions are reported here rather than printed: this
+                // process owns the terminal, and stderr would smear the frame.
+                self.status = Some(match created.ambiguous.first() {
+                    Some(ambiguous) => {
+                        Status::Error(format!("Saved thought #{}, but {}", created.id, ambiguous.describe()))
+                    }
+                    None => Status::Saved {
+                        id: created.id,
+                        entities: created.entities.len(),
+                    },
                 });
                 // Entities created by this save should be completable right away.
                 if let Err(e) = self.reload_candidates() {

--- a/src/tui/compose/mod.rs
+++ b/src/tui/compose/mod.rs
@@ -1,0 +1,377 @@
+//! Interactive thought composer.
+//!
+//! A small full-screen editor for entering new thoughts, reached via `wet add -i`
+//! (or bare `wet add`). It teaches the entry syntax while you type: the date field
+//! accepts relative forms and shows what they resolve to, typing `[` in the content
+//! field opens a fuzzy entity "whisperer" over known entity names and aliases, and a
+//! live preview colorizes mentions and flags the ones that would create a new entity.
+//!
+//! The composer stays open after each save so several thoughts can be entered in one
+//! sitting.
+
+pub mod input;
+pub mod state;
+pub mod ui;
+pub mod wrap;
+
+use std::collections::HashSet;
+
+use ratatui::crossterm::event::{self, Event, KeyEventKind};
+use ratatui::{Terminal, backend::Backend};
+use rusqlite::Connection;
+
+use crate::errors::ThoughtError;
+use crate::services::{date_parser, entity_parser, thought_writer};
+use crate::storage::entities_repository::EntitiesRepository;
+use crate::storage::entity_aliases_repository::EntityAliasesRepository;
+
+use state::{Candidate, Field, Whisperer};
+
+/// Outcome of the last save attempt, shown in the composer's status line.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub enum Status {
+    /// A thought was saved, with its ID and the number of entities linked
+    Saved { id: i64, entities: usize },
+    /// Something went wrong; the content field is left untouched
+    Error(String),
+}
+
+/// Root state for the interactive composer.
+///
+/// Unlike the browsing [`App`](crate::tui::App), which reopens a connection per
+/// mutation, the composer holds one connection open for its lifetime because it
+/// writes repeatedly.
+pub struct ComposeApp {
+    /// Text input for the thought content
+    pub content: tui_input::Input,
+    /// Text input for the date, parsed by `services::date_parser`
+    pub date: tui_input::Input,
+    /// Which field currently has focus
+    pub focus: Field,
+    /// Every completable entity name and alias, rebuilt after each save
+    pub candidates: Vec<Candidate>,
+    /// Lowercased canonical names and aliases, for the new-entity preview marker
+    pub known_lower: HashSet<String>,
+    /// The entity completion popup, when open
+    pub whisperer: Option<Whisperer>,
+    /// Result of the most recent save attempt
+    pub status: Option<Status>,
+    /// How many thoughts have been saved in this session
+    pub saved_count: usize,
+    /// Set when the user asks to leave
+    pub should_quit: bool,
+    conn: Connection,
+}
+
+impl ComposeApp {
+    /// Build a composer over an open, migrated connection.
+    ///
+    /// `initial_date` pre-fills the date field, e.g. from `wet add -i --date yesterday`.
+    pub fn new(conn: Connection, initial_date: Option<String>) -> Result<Self, ThoughtError> {
+        let mut app = Self {
+            content: tui_input::Input::default(),
+            date: tui_input::Input::new(initial_date.unwrap_or_default()),
+            focus: Field::Content,
+            candidates: Vec::new(),
+            known_lower: HashSet::new(),
+            whisperer: None,
+            status: None,
+            saved_count: 0,
+            should_quit: false,
+            conn,
+        };
+        app.reload_candidates()?;
+        Ok(app)
+    }
+
+    /// Rebuild the completion candidates and the known-entity set from the database.
+    ///
+    /// Called at startup and after each save, so entities a save just created become
+    /// completable immediately.
+    pub fn reload_candidates(&mut self) -> Result<(), ThoughtError> {
+        let entities = EntitiesRepository::list_all(&self.conn)?;
+        let mut candidates = Vec::new();
+        let mut known_lower = HashSet::new();
+
+        for entity in entities {
+            known_lower.insert(entity.canonical_name.to_lowercase());
+            candidates.push(Candidate {
+                label: entity.canonical_name.clone(),
+                canonical: entity.canonical_name.clone(),
+                is_alias: false,
+                description: entity.description.clone(),
+            });
+
+            let Some(entity_id) = entity.id else { continue };
+            for alias in EntityAliasesRepository::list_for_entity(&self.conn, entity_id)? {
+                known_lower.insert(alias.to_lowercase());
+                candidates.push(Candidate {
+                    label: alias,
+                    canonical: entity.canonical_name.clone(),
+                    is_alias: true,
+                    description: entity.description.clone(),
+                });
+            }
+        }
+
+        self.candidates = candidates;
+        self.known_lower = known_lower;
+        Ok(())
+    }
+
+    /// The labels of all candidates, in order, for fuzzy matching.
+    pub fn candidate_labels(&self) -> Vec<&str> {
+        self.candidates.iter().map(|c| c.label.as_str()).collect()
+    }
+
+    /// Resolve the date field to a calendar date.
+    ///
+    /// An empty field means "now", represented as `Ok(None)` so the saved thought
+    /// keeps a full timestamp rather than being pinned to midnight.
+    pub fn resolved_date(&self) -> Result<Option<chrono::NaiveDate>, ThoughtError> {
+        let raw = self.date.value().trim();
+        if raw.is_empty() {
+            return Ok(None);
+        }
+        date_parser::parse_date(raw).map(Some)
+    }
+
+    /// Shift the date field by `days`, rewriting it as an absolute `YYYY-MM-DD`.
+    ///
+    /// Lets the date be adjusted without leaving the content field. An empty field
+    /// counts as today. A field that doesn't parse is left alone — it is mid-edit,
+    /// and overwriting what is being typed would be worse than doing nothing.
+    pub fn nudge_date(&mut self, days: i64) {
+        let base = match self.resolved_date() {
+            Ok(Some(date)) => date,
+            Ok(None) => chrono::Utc::now().date_naive(),
+            Err(_) => return,
+        };
+
+        let magnitude = chrono::Days::new(days.unsigned_abs());
+        let shifted = if days < 0 {
+            base.checked_sub_days(magnitude)
+        } else {
+            base.checked_add_days(magnitude)
+        };
+
+        if let Some(shifted) = shifted {
+            self.date = tui_input::Input::new(shifted.format("%Y-%m-%d").to_string());
+        }
+    }
+
+    /// Entity names mentioned in the current content that don't match any known
+    /// entity or alias, and would therefore be created on save.
+    pub fn new_entity_mentions(&self) -> Vec<String> {
+        entity_parser::extract_unique_entities(self.content.value())
+            .into_iter()
+            .filter(|name| !self.known_lower.contains(&name.to_lowercase()))
+            .collect()
+    }
+
+    /// Save the current content as a thought.
+    ///
+    /// On success the content field is cleared while the date field is kept, so
+    /// several thoughts can be entered for the same date in a row. On failure the
+    /// content is left intact and the reason is recorded in [`Self::status`].
+    pub fn save(&mut self) {
+        let date = match self.resolved_date() {
+            Ok(date) => date,
+            Err(e) => {
+                self.status = Some(Status::Error(e.to_string()));
+                return;
+            }
+        };
+
+        // Trimmed so the space appended after a completion never reaches storage.
+        let content = self.content.value().trim().to_string();
+        match thought_writer::create_thought(&mut self.conn, &content, date) {
+            Ok((id, entities)) => {
+                self.content.reset();
+                self.whisperer = None;
+                self.saved_count += 1;
+                self.status = Some(Status::Saved {
+                    id,
+                    entities: entities.len(),
+                });
+                // Entities created by this save should be completable right away.
+                if let Err(e) = self.reload_candidates() {
+                    self.status = Some(Status::Error(e.to_string()));
+                }
+            }
+            Err(e) => self.status = Some(Status::Error(e.to_string())),
+        }
+    }
+
+    /// Run the composer's event loop until the user quits.
+    pub fn run(&mut self, terminal: &mut Terminal<impl Backend>) -> Result<(), ThoughtError> {
+        loop {
+            terminal
+                .draw(|frame| ui::render(self, frame))
+                .map_err(|e| ThoughtError::TuiError(e.to_string()))?;
+
+            let event = event::read().map_err(|e| ThoughtError::TuiError(e.to_string()))?;
+
+            if let Event::Key(key) = event
+                && key.kind == KeyEventKind::Press
+            {
+                input::handle_key_event(self, key);
+            }
+
+            if self.should_quit {
+                break;
+            }
+        }
+        Ok(())
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test_support {
+    use super::*;
+    use crate::models::entity::Entity;
+    use crate::storage::connection::get_memory_connection;
+    use crate::storage::migrations::run_migrations;
+
+    /// A composer over an in-memory database seeded with `Alice` (alias `alicia`),
+    /// `Bob`, and `Machine Learning`.
+    pub fn seeded_app() -> ComposeApp {
+        let conn = get_memory_connection().unwrap();
+        run_migrations(&conn).unwrap();
+
+        let alice = EntitiesRepository::find_or_create(&conn, &Entity::new("Alice".to_string())).unwrap();
+        EntityAliasesRepository::add_alias(&conn, alice, "alicia").unwrap();
+        EntitiesRepository::find_or_create(&conn, &Entity::new("Bob".to_string())).unwrap();
+        EntitiesRepository::find_or_create(&conn, &Entity::new("Machine Learning".to_string())).unwrap();
+
+        ComposeApp::new(conn, None).unwrap()
+    }
+
+    /// Type `text` into the composer one key at a time, exercising the real
+    /// key-handling path including whisperer recomputation.
+    pub fn type_text(app: &mut ComposeApp, text: &str) {
+        use ratatui::crossterm::event::{KeyCode, KeyEvent, KeyModifiers};
+        for ch in text.chars() {
+            super::input::handle_key_event(app, KeyEvent::new(KeyCode::Char(ch), KeyModifiers::NONE));
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::test_support::{seeded_app, type_text};
+    use super::*;
+
+    #[test]
+    fn test_candidates_include_canonical_names_and_aliases() {
+        let app = seeded_app();
+        let labels = app.candidate_labels();
+
+        assert!(labels.contains(&"Alice"));
+        assert!(labels.contains(&"alicia"));
+        assert!(labels.contains(&"Bob"));
+        assert!(labels.contains(&"Machine Learning"));
+    }
+
+    #[test]
+    fn test_alias_candidate_points_at_its_canonical_entity() {
+        let app = seeded_app();
+        let alias = app.candidates.iter().find(|c| c.label == "alicia").unwrap();
+
+        assert!(alias.is_alias);
+        assert_eq!(alias.canonical, "Alice");
+    }
+
+    #[test]
+    fn test_empty_date_field_resolves_to_none() {
+        let app = seeded_app();
+        assert_eq!(app.resolved_date().unwrap(), None);
+    }
+
+    #[test]
+    fn test_date_field_accepts_relative_forms() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("2026-08-01".to_string());
+
+        assert_eq!(
+            app.resolved_date().unwrap(),
+            Some(chrono::NaiveDate::from_ymd_opt(2026, 8, 1).unwrap())
+        );
+    }
+
+    #[test]
+    fn test_invalid_date_field_reports_an_error() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("nonsense".to_string());
+
+        assert!(app.resolved_date().is_err());
+    }
+
+    #[test]
+    fn test_new_entity_mentions_flags_only_unknown_names() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("[Alice] met [Carol] about [alicia]".to_string());
+
+        assert_eq!(app.new_entity_mentions(), vec!["Carol".to_string()]);
+    }
+
+    #[test]
+    fn test_save_persists_and_clears_content_but_keeps_date() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("2026-08-01".to_string());
+        type_text(&mut app, "talked to Alice");
+
+        app.save();
+
+        assert!(matches!(app.status, Some(Status::Saved { .. })));
+        assert_eq!(app.saved_count, 1);
+        assert_eq!(app.content.value(), "");
+        assert_eq!(app.date.value(), "2026-08-01");
+    }
+
+    #[test]
+    fn test_save_reports_linked_entity_count() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("[Alice] and [Bob]".to_string());
+
+        app.save();
+
+        assert_eq!(app.status, Some(Status::Saved { id: 1, entities: 2 }));
+    }
+
+    #[test]
+    fn test_save_makes_newly_created_entities_completable() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("met [Carol]".to_string());
+        assert!(!app.candidate_labels().contains(&"Carol"));
+
+        app.save();
+
+        assert!(app.candidate_labels().contains(&"Carol"));
+        assert!(app.known_lower.contains("carol"));
+    }
+
+    #[test]
+    fn test_save_with_invalid_date_keeps_content_and_reports_error() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("nonsense".to_string());
+        app.content = tui_input::Input::new("a thought".to_string());
+
+        app.save();
+
+        assert!(matches!(app.status, Some(Status::Error(_))));
+        assert_eq!(app.saved_count, 0);
+        assert_eq!(app.content.value(), "a thought");
+    }
+
+    #[test]
+    fn test_save_with_empty_content_keeps_composer_open() {
+        let mut app = seeded_app();
+
+        app.save();
+
+        assert!(matches!(app.status, Some(Status::Error(_))));
+        assert_eq!(app.saved_count, 0);
+        assert!(!app.should_quit);
+    }
+}

--- a/src/tui/compose/state.rs
+++ b/src/tui/compose/state.rs
@@ -1,0 +1,204 @@
+//! State types for the interactive thought composer.
+
+/// Which of the composer's two text fields currently has focus.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Field {
+    /// The date field, accepting the forms in `services::date_parser`
+    Date,
+    /// The thought content field, where the entity whisperer triggers
+    Content,
+}
+
+impl Field {
+    /// The other field, for Tab/Shift-Tab cycling.
+    pub fn toggled(self) -> Self {
+        match self {
+            Field::Date => Field::Content,
+            Field::Content => Field::Date,
+        }
+    }
+}
+
+/// A completion target offered by the entity whisperer: either an entity's
+/// canonical name or one of its registered aliases.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Candidate {
+    /// Text shown in the popup and fuzzy-matched against the query
+    pub label: String,
+    /// Canonical name of the entity this candidate resolves to
+    pub canonical: String,
+    /// True when `label` is an alias rather than the canonical name
+    pub is_alias: bool,
+    /// The entity's description, shown as a hint beside the label
+    pub description: Option<String>,
+}
+
+impl Candidate {
+    /// The text to insert when this candidate is accepted in `slot`.
+    pub fn insertion(&self, slot: Slot) -> String {
+        match slot {
+            // A whole reference. Canonical names insert as `[Name]`; registered
+            // aliases insert as `[alias](Name)`, displaying the alias but
+            // resolving to the entity.
+            Slot::Display if self.is_alias => format!("[{}]({})", self.label, self.canonical),
+            Slot::Display => format!("[{}]", self.label),
+            // Just the target of a reference whose display text the user already
+            // wrote, so only the canonical name is useful here.
+            Slot::Target => format!("({})", self.canonical),
+        }
+    }
+}
+
+/// Which part of an entity reference the whisperer is completing.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Slot {
+    /// Inside `[…`, opened by typing `[`. Accepting writes a whole reference.
+    Display,
+    /// Inside `](…`, opened by typing `(` straight after a `]`. Accepting writes
+    /// only the target, keeping the display wording the user already typed.
+    Target,
+}
+
+impl Slot {
+    /// The character that closes this slot's reference and dismisses the popup.
+    pub fn closing_char(self) -> char {
+        match self {
+            Slot::Display => ']',
+            Slot::Target => ')',
+        }
+    }
+
+    /// The character that opens this slot, expected to sit at `Whisperer::open_at`.
+    pub fn opening_char(self) -> char {
+        match self {
+            Slot::Display => '[',
+            Slot::Target => '(',
+        }
+    }
+}
+
+/// State of the entity completion popup.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Whisperer {
+    /// Character index in the content field of the bracket that opened this popup.
+    ///
+    /// Counted in codepoints to match `tui_input::Input::cursor`.
+    pub open_at: usize,
+    /// Which part of the reference is being completed
+    pub slot: Slot,
+    /// Indices into `ComposeApp::candidates`, best match first
+    pub matches: Vec<usize>,
+    /// Currently highlighted entry in `matches`
+    pub selected: usize,
+}
+
+impl Whisperer {
+    /// Move the highlight up one entry, stopping at the top.
+    pub fn select_previous(&mut self) {
+        self.selected = self.selected.saturating_sub(1);
+    }
+
+    /// Move the highlight down one entry, stopping at the bottom.
+    pub fn select_next(&mut self) {
+        if self.selected + 1 < self.matches.len() {
+            self.selected += 1;
+        }
+    }
+
+    /// Index into `ComposeApp::candidates` of the highlighted entry, if any.
+    pub fn selected_candidate(&self) -> Option<usize> {
+        self.matches.get(self.selected).copied()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn candidate(label: &str, canonical: &str, is_alias: bool) -> Candidate {
+        Candidate {
+            label: label.to_string(),
+            canonical: canonical.to_string(),
+            is_alias,
+            description: None,
+        }
+    }
+
+    #[test]
+    fn test_field_toggles_between_date_and_content() {
+        assert_eq!(Field::Date.toggled(), Field::Content);
+        assert_eq!(Field::Content.toggled(), Field::Date);
+    }
+
+    #[test]
+    fn test_canonical_candidate_inserts_plain_reference() {
+        assert_eq!(candidate("Alice", "Alice", false).insertion(Slot::Display), "[Alice]");
+    }
+
+    #[test]
+    fn test_alias_candidate_inserts_aliased_reference() {
+        assert_eq!(
+            candidate("alicia", "Alice", true).insertion(Slot::Display),
+            "[alicia](Alice)"
+        );
+    }
+
+    #[test]
+    fn test_target_slot_inserts_only_the_canonical_name() {
+        assert_eq!(candidate("Alice", "Alice", false).insertion(Slot::Target), "(Alice)");
+        // The display wording is already written, so an alias contributes only
+        // the entity it points at.
+        assert_eq!(candidate("alicia", "Alice", true).insertion(Slot::Target), "(Alice)");
+    }
+
+    #[test]
+    fn test_slot_delimiters() {
+        assert_eq!(Slot::Display.opening_char(), '[');
+        assert_eq!(Slot::Display.closing_char(), ']');
+        assert_eq!(Slot::Target.opening_char(), '(');
+        assert_eq!(Slot::Target.closing_char(), ')');
+    }
+
+    #[test]
+    fn test_whisperer_selection_is_clamped_at_both_ends() {
+        let mut whisperer = Whisperer {
+            open_at: 0,
+            slot: Slot::Display,
+            matches: vec![3, 7],
+            selected: 0,
+        };
+
+        whisperer.select_previous();
+        assert_eq!(whisperer.selected, 0);
+
+        whisperer.select_next();
+        assert_eq!(whisperer.selected, 1);
+        whisperer.select_next();
+        assert_eq!(whisperer.selected, 1);
+
+        whisperer.select_previous();
+        assert_eq!(whisperer.selected, 0);
+    }
+
+    #[test]
+    fn test_selected_candidate_maps_through_matches() {
+        let whisperer = Whisperer {
+            open_at: 0,
+            slot: Slot::Display,
+            matches: vec![3, 7],
+            selected: 1,
+        };
+        assert_eq!(whisperer.selected_candidate(), Some(7));
+    }
+
+    #[test]
+    fn test_selected_candidate_is_none_when_no_matches() {
+        let whisperer = Whisperer {
+            open_at: 0,
+            slot: Slot::Display,
+            matches: vec![],
+            selected: 0,
+        };
+        assert_eq!(whisperer.selected_candidate(), None);
+    }
+}

--- a/src/tui/compose/ui.rs
+++ b/src/tui/compose/ui.rs
@@ -23,7 +23,10 @@ const WHISPERER_MAX_ROWS: usize = 8;
 /// Most rows the content field grows to before it starts scrolling.
 const CONTENT_MAX_ROWS: usize = 6;
 
-/// Most rows the preview grows to before it stops showing more.
+/// Most rows the preview's resolved text grows to before it stops showing more.
+///
+/// The `+new:` marker gets its own reserved row on top of this, so it can never
+/// be the thing wrapping drops.
 const PREVIEW_MAX_ROWS: usize = 4;
 
 /// Render the whole composer frame.
@@ -59,26 +62,21 @@ pub fn render(app: &ComposeApp, frame: &mut Frame) {
     place_cursor(app, frame, chunks[0], chunks[1], &wrapped, content_scroll);
 }
 
-/// How many rows the preview needs, capped.
+/// How many rows the preview needs: its resolved text, capped, plus a reserved
+/// row for the `+new:` marker when there is one.
 fn preview_row_count(app: &ComposeApp, width: usize) -> usize {
     let content = app.content.value();
+    let marker_rows = usize::from(!app.new_entity_mentions().is_empty());
     if content.trim().is_empty() {
-        return 1;
+        return 1 + marker_rows;
     }
-    // The preview renders resolved display text plus any `+new:` marker, so
-    // measure that rather than the raw markup.
+    // Measure the resolved display text, not the raw markup.
     let rendered: String = styled_content_line(content, usize::MAX)
         .spans
         .iter()
         .map(|s| s.content.as_ref())
         .collect();
-    let marker = app.new_entity_mentions();
-    let measured = if marker.is_empty() {
-        rendered
-    } else {
-        format!("{}   +new: {}", rendered, marker.join(", "))
-    };
-    wrap::wrap(&measured, 0, width).rows.len().clamp(1, PREVIEW_MAX_ROWS)
+    wrap::wrap(&rendered, 0, width).rows.len().clamp(1, PREVIEW_MAX_ROWS) + marker_rows
 }
 
 /// Style for the border of a field, highlighted when focused.
@@ -163,22 +161,34 @@ fn render_preview(app: &ComposeApp, frame: &mut Frame, area: Rect) {
         ))
     } else {
         // Never truncate — the paragraph wraps instead, matching the content field.
-        let mut spans = styled_content_line(content, usize::MAX).spans;
-        let new_mentions = app.new_entity_mentions();
-        if !new_mentions.is_empty() {
-            spans.push(Span::styled(
-                format!("   +new: {}", new_mentions.join(", ")),
-                Style::default().fg(Color::Yellow).add_modifier(Modifier::DIM),
-            ));
-        }
-        Line::from(spans)
+        Line::from(styled_content_line(content, usize::MAX).spans)
     };
 
     let block = Block::default()
         .borders(Borders::ALL)
         .border_style(Style::default().fg(Color::DarkGray))
         .title("Preview");
-    frame.render_widget(Paragraph::new(line).block(block).wrap(Wrap { trim: false }), area);
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // The marker gets its own row at the bottom rather than trailing the text.
+    // Appended inline it was the first thing wrapping dropped, so it vanished
+    // exactly on the long thoughts where a typo is most likely.
+    let new_mentions = app.new_entity_mentions();
+    let marker_rows = u16::from(!new_mentions.is_empty());
+    let [text_area, marker_area] = Layout::vertical([Constraint::Min(0), Constraint::Length(marker_rows)]).areas(inner);
+
+    frame.render_widget(Paragraph::new(line).wrap(Wrap { trim: false }), text_area);
+
+    if marker_rows > 0 {
+        frame.render_widget(
+            Paragraph::new(Line::from(Span::styled(
+                format!("+new: {}", new_mentions.join(", ")),
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::DIM),
+            ))),
+            marker_area,
+        );
+    }
 }
 
 /// Render the running session status: saves so far and the last outcome.
@@ -464,6 +474,32 @@ mod tests {
 
         assert!(out.contains("+new: Carol"), "{}", out);
         assert!(!out.contains("+new: Alice"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_preview_keeps_the_new_marker_on_long_thoughts() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new(format!("{} met [Carol]", "some longer words here ".repeat(6)));
+
+        let out = render_to_string(&app, 40, 30);
+
+        // Appended inline, the marker was the first thing wrapping dropped.
+        assert!(out.contains("+new: Carol"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_preview_marker_sits_on_its_own_row() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("met [Carol]".to_string());
+
+        let out = render_to_string(&app, 60, 24);
+
+        let marker_row = out.lines().find(|l| l.contains("+new:")).expect("marker row");
+        assert!(
+            !marker_row.contains("met Carol"),
+            "marker must not share a row with the text: {:?}",
+            marker_row
+        );
     }
 
     #[test]

--- a/src/tui/compose/ui.rs
+++ b/src/tui/compose/ui.rs
@@ -1,0 +1,619 @@
+//! Rendering for the interactive composer.
+//!
+//! Lays out the date field, the content field, the live preview, and a persistent
+//! syntax help footer, plus the entity whisperer popup anchored under the cursor.
+
+use ratatui::{
+    Frame,
+    layout::{Constraint, Layout, Rect},
+    style::{Color, Modifier, Style},
+    text::{Line, Span},
+    widgets::{Block, Borders, Clear, List, ListItem, Paragraph, Wrap},
+};
+
+use super::state::{Field, Slot};
+use super::wrap;
+use super::{ComposeApp, Status};
+use crate::services::date_parser;
+use crate::tui::ui::styled_content_line;
+
+/// Maximum number of whisperer entries shown at once.
+const WHISPERER_MAX_ROWS: usize = 8;
+
+/// Most rows the content field grows to before it starts scrolling.
+const CONTENT_MAX_ROWS: usize = 6;
+
+/// Most rows the preview grows to before it stops showing more.
+const PREVIEW_MAX_ROWS: usize = 4;
+
+/// Render the whole composer frame.
+pub fn render(app: &ComposeApp, frame: &mut Frame) {
+    let area = frame.area();
+
+    // Both text areas grow with their content up to a cap, so a one-line thought
+    // gets a one-line box and a long one gets room to wrap.
+    let text_width = area.width.saturating_sub(2) as usize;
+    let wrapped = wrap::wrap(app.content.value(), app.content.cursor(), text_width);
+    let content_rows = wrapped.rows.len().clamp(1, CONTENT_MAX_ROWS) as u16;
+    let preview_rows = preview_row_count(app, text_width) as u16;
+
+    let chunks = Layout::vertical([
+        Constraint::Length(3),                // date field
+        Constraint::Length(content_rows + 2), // content field
+        Constraint::Length(preview_rows + 2), // live preview
+        Constraint::Min(0),                   // status / new-entity notes
+        Constraint::Length(2),                // help footer
+    ])
+    .split(area);
+
+    render_date_field(app, frame, chunks[0]);
+    let content_scroll = render_content_field(app, frame, chunks[1], &wrapped);
+    render_preview(app, frame, chunks[2]);
+    render_status(app, frame, chunks[3]);
+    render_help(frame, chunks[4]);
+
+    // The popup tracks the cursor's column but hangs below the preview, so the
+    // preview stays readable while you are picking an entity.
+    render_whisperer(app, frame, chunks[1], chunks[2].bottom(), area, &wrapped);
+
+    place_cursor(app, frame, chunks[0], chunks[1], &wrapped, content_scroll);
+}
+
+/// How many rows the preview needs, capped.
+fn preview_row_count(app: &ComposeApp, width: usize) -> usize {
+    let content = app.content.value();
+    if content.trim().is_empty() {
+        return 1;
+    }
+    // The preview renders resolved display text plus any `+new:` marker, so
+    // measure that rather than the raw markup.
+    let rendered: String = styled_content_line(content, usize::MAX)
+        .spans
+        .iter()
+        .map(|s| s.content.as_ref())
+        .collect();
+    let marker = app.new_entity_mentions();
+    let measured = if marker.is_empty() {
+        rendered
+    } else {
+        format!("{}   +new: {}", rendered, marker.join(", "))
+    };
+    wrap::wrap(&measured, 0, width).rows.len().clamp(1, PREVIEW_MAX_ROWS)
+}
+
+/// Style for the border of a field, highlighted when focused.
+fn border_style(app: &ComposeApp, field: Field) -> Style {
+    if app.focus == field {
+        Style::default().fg(Color::Cyan)
+    } else {
+        Style::default().fg(Color::DarkGray)
+    }
+}
+
+/// Render the date field with its live resolution or parse error.
+fn render_date_field(app: &ComposeApp, frame: &mut Frame, area: Rect) {
+    let raw = app.date.value();
+    let hint = if raw.trim().is_empty() {
+        Span::styled(" → now", Style::default().fg(Color::DarkGray))
+    } else {
+        match date_parser::parse_date(raw) {
+            // Echoing an already-absolute date back at the user is noise — which
+            // it always is after an Alt-arrow nudge — so just name the weekday.
+            Ok(date) if date.format("%Y-%m-%d").to_string() == raw.trim() => {
+                Span::styled(format!("  ({})", date.format("%a")), Style::default().fg(Color::Green))
+            }
+            Ok(date) => Span::styled(
+                format!(" → {}", date.format("%Y-%m-%d (%a)")),
+                Style::default().fg(Color::Green),
+            ),
+            Err(_) => Span::styled(
+                format!(" → unrecognized ({})", date_parser::ACCEPTED_FORMS),
+                Style::default().fg(Color::Red),
+            ),
+        }
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style(app, Field::Date))
+        .title("Date");
+    let line = Line::from(vec![Span::raw(raw.to_string()), hint]);
+    frame.render_widget(Paragraph::new(line).block(block), area);
+}
+
+/// Render the raw content field, where entity markup is shown verbatim, wrapped
+/// over as many rows as fit.
+///
+/// Returns the first visible row index, so the cursor can be placed against the
+/// same scroll position.
+fn render_content_field(app: &ComposeApp, frame: &mut Frame, area: Rect, wrapped: &wrap::Wrapped) -> usize {
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(border_style(app, Field::Content))
+        .title("Thought");
+    let inner = block.inner(area);
+    frame.render_widget(block, area);
+
+    // Scroll only once the text outgrows the box, keeping the cursor's row in view.
+    let visible = (inner.height as usize).max(1);
+    let scroll = wrapped.cursor_row.saturating_sub(visible.saturating_sub(1));
+
+    let chars: Vec<char> = app.content.value().chars().collect();
+    let lines: Vec<Line> = wrapped
+        .rows
+        .iter()
+        .skip(scroll)
+        .take(visible)
+        .map(|row| Line::from(chars[row.start..row.end].iter().collect::<String>()))
+        .collect();
+
+    frame.render_widget(Paragraph::new(lines), inner);
+    scroll
+}
+
+/// Render the live preview: entity markup resolved and colorized, with a marker
+/// on every mention that would create a new entity.
+fn render_preview(app: &ComposeApp, frame: &mut Frame, area: Rect) {
+    let content = app.content.value();
+
+    let line = if content.trim().is_empty() {
+        Line::from(Span::styled(
+            "(nothing to preview yet)",
+            Style::default().fg(Color::DarkGray),
+        ))
+    } else {
+        // Never truncate — the paragraph wraps instead, matching the content field.
+        let mut spans = styled_content_line(content, usize::MAX).spans;
+        let new_mentions = app.new_entity_mentions();
+        if !new_mentions.is_empty() {
+            spans.push(Span::styled(
+                format!("   +new: {}", new_mentions.join(", ")),
+                Style::default().fg(Color::Yellow).add_modifier(Modifier::DIM),
+            ));
+        }
+        Line::from(spans)
+    };
+
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::DarkGray))
+        .title("Preview");
+    frame.render_widget(Paragraph::new(line).block(block).wrap(Wrap { trim: false }), area);
+}
+
+/// Render the running session status: saves so far and the last outcome.
+fn render_status(app: &ComposeApp, frame: &mut Frame, area: Rect) {
+    if area.height == 0 {
+        return;
+    }
+
+    let line = match &app.status {
+        Some(Status::Saved { id, entities }) => Line::from(vec![
+            Span::styled(format!(" Saved thought #{}", id), Style::default().fg(Color::Green)),
+            Span::styled(
+                format!(
+                    " ({} entit{}) · {} saved this session",
+                    entities,
+                    if *entities == 1 { "y" } else { "ies" },
+                    app.saved_count
+                ),
+                Style::default().fg(Color::DarkGray),
+            ),
+        ]),
+        Some(Status::Error(message)) => {
+            Line::from(Span::styled(format!(" {}", message), Style::default().fg(Color::Red)))
+        }
+        None => Line::from(Span::styled(
+            " Type a thought, then press Enter to save.",
+            Style::default().fg(Color::DarkGray),
+        )),
+    };
+
+    frame.render_widget(Paragraph::new(line), area);
+}
+
+/// Render the persistent syntax help footer.
+fn render_help(frame: &mut Frame, area: Rect) {
+    let style = Style::default().fg(Color::DarkGray);
+    let lines = vec![
+        Line::from(Span::styled(
+            " Entities: [Name] · [your wording](Name) — type [ or ]( to search",
+            style,
+        )),
+        Line::from(Span::styled(
+            " Date: YYYY-MM-DD · today · -3d · mon · Alt+←/→ shifts a day   Tab:field · Enter:save · Esc:quit",
+            style,
+        )),
+    ];
+    frame.render_widget(Paragraph::new(lines), area);
+}
+
+/// Render the entity completion popup.
+///
+/// It lines up with the cursor's column in the content field but hangs from
+/// `top`, so it never hides the preview.
+fn render_whisperer(
+    app: &ComposeApp,
+    frame: &mut Frame,
+    content_area: Rect,
+    top: u16,
+    area: Rect,
+    wrapped: &wrap::Wrapped,
+) {
+    let Some(whisperer) = app.whisperer.as_ref() else {
+        return;
+    };
+
+    let rows = whisperer.matches.len().clamp(1, WHISPERER_MAX_ROWS) as u16;
+    let height = (rows + 2).min(area.height.saturating_sub(top).max(3));
+    let width = 48.min(area.width);
+    // Track the cursor's wrapped column, but never run past the right edge.
+    let x = (content_area.x + 1 + wrapped.cursor_col as u16).min(area.right().saturating_sub(width));
+    let y = top.min(area.bottom().saturating_sub(height));
+    let popup = Rect { x, y, width, height };
+
+    frame.render_widget(Clear, popup);
+    let title = match whisperer.slot {
+        Slot::Display => "Entities",
+        // Name the slot, so it is obvious the pick replaces only the target and
+        // leaves the wording already typed alone.
+        Slot::Target => "Entities → links to",
+    };
+    let block = Block::default()
+        .borders(Borders::ALL)
+        .border_style(Style::default().fg(Color::Cyan))
+        .title(title);
+    let inner = block.inner(popup);
+    frame.render_widget(block, popup);
+
+    if whisperer.matches.is_empty() {
+        frame.render_widget(
+            Paragraph::new(Span::styled(
+                "no match — will create a new entity",
+                Style::default().fg(Color::Yellow),
+            )),
+            inner,
+        );
+        return;
+    }
+
+    // Scroll so the highlighted entry stays visible.
+    let visible = inner.height as usize;
+    let start = whisperer.selected.saturating_sub(visible.saturating_sub(1));
+
+    let items: Vec<ListItem> = whisperer
+        .matches
+        .iter()
+        .enumerate()
+        .skip(start)
+        .take(visible)
+        .map(|(row, &candidate_idx)| {
+            let candidate = &app.candidates[candidate_idx];
+            let mut spans = vec![Span::styled(
+                candidate.label.clone(),
+                Style::default().add_modifier(Modifier::BOLD),
+            )];
+            if candidate.is_alias {
+                spans.push(Span::styled(
+                    format!(" → {}", candidate.canonical),
+                    Style::default().fg(Color::Cyan),
+                ));
+            }
+            if let Some(description) = candidate.description.as_deref()
+                && !description.trim().is_empty()
+            {
+                spans.push(Span::styled(
+                    format!("  {}", first_line(description)),
+                    Style::default().fg(Color::DarkGray),
+                ));
+            }
+
+            let mut item = ListItem::new(Line::from(spans));
+            if row == whisperer.selected {
+                item = item.style(Style::default().add_modifier(Modifier::REVERSED));
+            }
+            item
+        })
+        .collect();
+
+    frame.render_widget(List::new(items), inner);
+}
+
+/// First line of a description, for the one-line hint beside a candidate.
+fn first_line(description: &str) -> &str {
+    description.lines().next().unwrap_or("").trim()
+}
+
+/// Put the terminal cursor in the focused field.
+///
+/// The date field is a single short line, so its column is the input's own visual
+/// cursor. The content field is wrapped, so its position comes from the same
+/// [`wrap::Wrapped`] the rows were rendered from — the two cannot drift apart.
+fn place_cursor(
+    app: &ComposeApp,
+    frame: &mut Frame,
+    date_area: Rect,
+    content_area: Rect,
+    wrapped: &wrap::Wrapped,
+    content_scroll: usize,
+) {
+    // +1 on each axis for the block's left and top borders.
+    let (area, col, row) = match app.focus {
+        Field::Date => (date_area, app.date.visual_cursor(), 0),
+        Field::Content => (
+            content_area,
+            wrapped.cursor_col,
+            wrapped.cursor_row.saturating_sub(content_scroll),
+        ),
+    };
+
+    let x = (area.x + 1 + col as u16).min(area.right().saturating_sub(1));
+    let y = (area.y + 1 + row as u16).min(area.bottom().saturating_sub(2).max(area.y));
+    frame.set_cursor_position((x, y));
+}
+
+#[cfg(test)]
+mod tests {
+    use super::super::test_support::{seeded_app, type_text};
+    use super::*;
+    use ratatui::{Terminal, backend::TestBackend};
+
+    fn render_to_string(app: &ComposeApp, width: u16, height: u16) -> String {
+        let backend = TestBackend::new(width, height);
+        let mut terminal = Terminal::new(backend).unwrap();
+        terminal.draw(|frame| render(app, frame)).unwrap();
+
+        let buffer = terminal.backend().buffer();
+        let mut out = String::new();
+        for y in 0..buffer.area.height {
+            for x in 0..buffer.area.width {
+                out.push_str(buffer[(x, y)].symbol());
+            }
+            out.push('\n');
+        }
+        out
+    }
+
+    #[test]
+    fn test_render_shows_field_titles_and_help_footer() {
+        let app = seeded_app();
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("Date"), "{}", out);
+        assert!(out.contains("Thought"), "{}", out);
+        assert!(out.contains("Preview"), "{}", out);
+        assert!(out.contains("[Name]"), "{}", out);
+        assert!(out.contains("[your wording](Name)"), "{}", out);
+        assert!(out.contains("type [ or ]( to search"), "{}", out);
+        assert!(out.contains("Alt+←/→ shifts a day"), "{}", out);
+        assert!(out.contains("Enter:save"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_target_whisperer_names_the_slot() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [my boss](al");
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("links to"), "{}", out);
+        assert!(out.contains("Alice"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_empty_date_field_reads_as_now() {
+        let app = seeded_app();
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("→ now"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_resolves_a_relative_date_field() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("yesterday".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        let expected = chrono::Utc::now().date_naive().pred_opt().unwrap();
+        assert!(
+            out.contains(&format!("→ {}", expected.format("%Y-%m-%d (%a)"))),
+            "{}",
+            out
+        );
+    }
+
+    #[test]
+    fn test_render_does_not_echo_an_already_absolute_date() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("2026-08-01".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("2026-08-01  (Sat)"), "{}", out);
+        assert!(!out.contains("→ 2026-08-01"), "redundant echo: {}", out);
+    }
+
+    #[test]
+    fn test_render_flags_an_unrecognized_date() {
+        let mut app = seeded_app();
+        app.date = tui_input::Input::new("nonsense".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("unrecognized"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_preview_resolves_entity_markup() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("paired with [alicia](Alice)".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        // The preview drops the markup and shows the display text.
+        assert!(out.contains("paired with alicia"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_preview_marks_new_entities() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("met [Alice] and [Carol]".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("+new: Carol"), "{}", out);
+        assert!(!out.contains("+new: Alice"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_preview_omits_marker_when_all_entities_are_known() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("met [Alice]".to_string());
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(!out.contains("+new"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_whisperer_lists_matching_entities() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("Entities"), "{}", out);
+        assert!(out.contains("Alice"), "{}", out);
+        assert!(out.contains("alicia"), "{}", out);
+        assert!(!out.contains("Bob"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_whisperer_marks_aliases_with_their_target() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[alicia");
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("alicia → Alice"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_whisperer_explains_an_empty_match_list() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[zzzz");
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("no match"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_reports_the_last_save() {
+        let mut app = seeded_app();
+        type_text(&mut app, "met [Alice]");
+        app.save();
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("Saved thought #1"), "{}", out);
+        assert!(out.contains("1 entity"), "{}", out);
+        assert!(out.contains("1 saved this session"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_reports_a_save_error() {
+        let mut app = seeded_app();
+        app.save(); // empty content
+
+        let out = render_to_string(&app, 100, 20);
+
+        assert!(out.contains("empty") || out.contains("Empty"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_wraps_content_past_the_right_edge() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new(
+            "the quick brown fox jumps over the lazy dog and keeps on running well past the edge".to_string(),
+        );
+
+        let out = render_to_string(&app, 40, 24);
+
+        // Every word survives, so nothing was silently cut off at the edge.
+        for word in ["quick", "jumps", "lazy", "running", "past", "edge"] {
+            assert!(out.contains(word), "lost {:?} in:\n{}", word, out);
+        }
+        // And it really is on more than one row of the Thought box.
+        assert!(out.matches("running").count() >= 1);
+        assert!(!out.contains("…"), "{}", out);
+    }
+
+    #[test]
+    fn test_content_box_grows_with_the_text() {
+        let mut app = seeded_app();
+        let short = render_to_string(&app, 40, 24);
+
+        app.content = tui_input::Input::new("word ".repeat(30));
+        let long = render_to_string(&app, 40, 24);
+
+        let box_rows = |s: &str| s.lines().filter(|l| l.contains('│')).count();
+        assert!(
+            box_rows(&long) > box_rows(&short),
+            "long content should occupy more rows\nshort:\n{}\nlong:\n{}",
+            short,
+            long
+        );
+    }
+
+    #[test]
+    fn test_content_box_stops_growing_at_the_cap() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("word ".repeat(200));
+
+        let out = render_to_string(&app, 100, 24);
+
+        // Capped, so everything below the field is still on screen.
+        assert!(out.contains("Preview"), "{}", out);
+        assert!(out.contains("Enter:save"), "{}", out);
+
+        let thought_rows = out
+            .lines()
+            .skip_while(|l| !l.contains("Thought"))
+            .skip(1)
+            .take_while(|l| !l.starts_with('└'))
+            .count();
+        assert_eq!(thought_rows, CONTENT_MAX_ROWS, "field should stop at the cap:\n{}", out);
+    }
+
+    #[test]
+    fn test_long_content_scrolls_to_keep_the_end_visible() {
+        let mut app = seeded_app();
+        let text = format!("{}CARET", "filler ".repeat(60));
+        app.content = tui_input::Input::new(text);
+
+        let out = render_to_string(&app, 40, 24);
+
+        assert!(out.contains("CARET"), "the cursor's row must stay in view:\n{}", out);
+    }
+
+    #[test]
+    fn test_render_handles_narrow_terminals() {
+        let mut app = seeded_app();
+        type_text(&mut app, "[ali");
+
+        // Must not panic or overflow when there is barely room for the popup.
+        let out = render_to_string(&app, 24, 14);
+        assert!(out.contains("Date"), "{}", out);
+    }
+
+    #[test]
+    fn test_render_handles_multibyte_content() {
+        let mut app = seeded_app();
+        app.content = tui_input::Input::new("obédèd naïve 日本語 [Alice] ✨".repeat(8));
+
+        let out = render_to_string(&app, 40, 14);
+        assert!(out.contains("Preview"), "{}", out);
+    }
+}

--- a/src/tui/compose/wrap.rs
+++ b/src/tui/compose/wrap.rs
@@ -1,0 +1,243 @@
+//! Word wrapping for the composer's content field.
+//!
+//! `tui_input::Input` holds a single logical line with no newlines, but a thought
+//! easily runs past the right edge. This module lays that line out over several
+//! visual rows and reports where the cursor lands, so rendering and cursor
+//! placement are derived from one computation and cannot disagree.
+//!
+//! Widths are counted in display columns (via `unicode-width`), not characters, so
+//! wide glyphs do not overflow the field and get clipped.
+
+use unicode_width::UnicodeWidthChar;
+
+/// A single visual row: a half-open range of character indices into the content.
+///
+/// Rows tile the content exactly — every character belongs to exactly one row —
+/// which is what makes mapping a cursor index to a row unambiguous.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct Row {
+    /// First character index on this row
+    pub start: usize,
+    /// One past the last character index on this row
+    pub end: usize,
+}
+
+/// Content laid out over visual rows, with the cursor located within them.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct Wrapped {
+    /// Visual rows, always at least one (empty content yields one empty row)
+    pub rows: Vec<Row>,
+    /// Index into `rows` of the row holding the cursor
+    pub cursor_row: usize,
+    /// Display-column offset of the cursor within `cursor_row`
+    pub cursor_col: usize,
+}
+
+/// Display width of a character, treating control characters as zero-width.
+fn char_width(c: char) -> usize {
+    c.width().unwrap_or(0)
+}
+
+/// Lay `text` out over rows no wider than `width` display columns, and locate
+/// `cursor` (a character index) within them.
+///
+/// Breaks at spaces where possible, keeping the space at the end of the row it
+/// breaks after so the rows stay contiguous. A word longer than `width` is broken
+/// hard rather than overflowing.
+pub fn wrap(text: &str, cursor: usize, width: usize) -> Wrapped {
+    let chars: Vec<char> = text.chars().collect();
+    let width = width.max(1);
+    let mut rows = Vec::new();
+    let mut start = 0;
+
+    while start < chars.len() {
+        let mut end = start;
+        let mut used = 0;
+        // Last index at which we saw a space, as a preferred break point.
+        let mut last_space: Option<usize> = None;
+
+        while end < chars.len() {
+            let w = char_width(chars[end]);
+            if used + w > width {
+                break;
+            }
+            used += w;
+            if chars[end] == ' ' {
+                last_space = Some(end);
+            }
+            end += 1;
+        }
+
+        if end == chars.len() {
+            rows.push(Row { start, end });
+            break;
+        }
+
+        // Overflowed. Prefer breaking after the last space on this row; if the row
+        // is one long word, break it hard at the column limit.
+        let break_at = match last_space {
+            Some(space) if space + 1 > start => space + 1,
+            _ => end.max(start + 1),
+        };
+        rows.push(Row { start, end: break_at });
+        start = break_at;
+    }
+
+    // An empty field still needs a row to put the cursor on. So does a full last
+    // row when the cursor sits past its end — there is nowhere else to draw it.
+    // Only then, so text that merely happens to end on a boundary gains no
+    // spurious blank row.
+    let cursor_needs_a_new_row = cursor >= chars.len() && rows.last().is_some_and(|r| row_is_full(&chars, *r, width));
+    if rows.is_empty() || cursor_needs_a_new_row {
+        rows.push(Row {
+            start: chars.len(),
+            end: chars.len(),
+        });
+    }
+
+    let (cursor_row, cursor_col) = locate_cursor(&chars, &rows, cursor);
+    Wrapped {
+        rows,
+        cursor_row,
+        cursor_col,
+    }
+}
+
+/// Whether a row exactly fills the available width.
+fn row_is_full(chars: &[char], row: Row, width: usize) -> bool {
+    chars[row.start..row.end].iter().copied().map(char_width).sum::<usize>() >= width
+}
+
+/// Map a character index to a row and a display-column offset within it.
+fn locate_cursor(chars: &[char], rows: &[Row], cursor: usize) -> (usize, usize) {
+    let cursor = cursor.min(chars.len());
+    for (i, row) in rows.iter().enumerate() {
+        // The final row owns the position one past the last character.
+        let owns_end = i == rows.len() - 1;
+        if (cursor >= row.start && cursor < row.end) || (owns_end && cursor >= row.start) {
+            let col = chars[row.start..cursor.min(row.end.max(row.start))]
+                .iter()
+                .copied()
+                .map(char_width)
+                .sum();
+            return (i, col);
+        }
+    }
+    (0, 0)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// The text of each row, for readable assertions.
+    fn row_texts(text: &str, wrapped: &Wrapped) -> Vec<String> {
+        let chars: Vec<char> = text.chars().collect();
+        wrapped
+            .rows
+            .iter()
+            .map(|r| chars[r.start..r.end].iter().collect())
+            .collect()
+    }
+
+    #[test]
+    fn test_short_text_stays_on_one_row() {
+        let wrapped = wrap("hello", 5, 20);
+        assert_eq!(row_texts("hello", &wrapped), vec!["hello"]);
+        assert_eq!((wrapped.cursor_row, wrapped.cursor_col), (0, 5));
+    }
+
+    #[test]
+    fn test_empty_text_still_has_a_row_for_the_cursor() {
+        let wrapped = wrap("", 0, 20);
+        assert_eq!(wrapped.rows.len(), 1);
+        assert_eq!((wrapped.cursor_row, wrapped.cursor_col), (0, 0));
+    }
+
+    #[test]
+    fn test_breaks_at_a_space_not_mid_word() {
+        let text = "the quick brown fox";
+        let wrapped = wrap(text, 0, 10);
+        // "the quick " fits in 10; "brown" would not.
+        assert_eq!(row_texts(text, &wrapped), vec!["the quick ", "brown fox"]);
+    }
+
+    #[test]
+    fn test_rows_tile_the_text_exactly() {
+        let text = "alpha beta gamma delta epsilon zeta";
+        let wrapped = wrap(text, 0, 12);
+
+        assert_eq!(wrapped.rows[0].start, 0);
+        for pair in wrapped.rows.windows(2) {
+            assert_eq!(pair[0].end, pair[1].start, "rows must be contiguous");
+        }
+        assert_eq!(row_texts(text, &wrapped).concat(), text);
+    }
+
+    #[test]
+    fn test_word_longer_than_the_width_is_broken_hard() {
+        let text = "supercalifragilistic";
+        let wrapped = wrap(text, 0, 8);
+        assert_eq!(row_texts(text, &wrapped), vec!["supercal", "ifragili", "stic"]);
+    }
+
+    #[test]
+    fn test_cursor_follows_onto_the_wrapped_row() {
+        let text = "the quick brown fox";
+        // Cursor at the very end.
+        let wrapped = wrap(text, text.chars().count(), 10);
+        assert_eq!(wrapped.cursor_row, 1);
+        assert_eq!(wrapped.cursor_col, "brown fox".len());
+    }
+
+    #[test]
+    fn test_cursor_at_a_row_boundary_belongs_to_the_later_row() {
+        let text = "the quick brown fox";
+        // Index 10 is the first char of "brown", i.e. the start of row 1.
+        let wrapped = wrap(text, 10, 10);
+        assert_eq!((wrapped.cursor_row, wrapped.cursor_col), (1, 0));
+    }
+
+    #[test]
+    fn test_text_ending_exactly_at_the_boundary_gets_a_row_for_the_cursor() {
+        let text = "abcdefghij"; // exactly 10
+        let wrapped = wrap(text, 10, 10);
+        assert_eq!(wrapped.rows.len(), 2, "cursor needs somewhere to sit");
+        assert_eq!((wrapped.cursor_row, wrapped.cursor_col), (1, 0));
+    }
+
+    #[test]
+    fn test_wide_glyphs_wrap_by_display_width() {
+        // Each CJK glyph is two columns wide, so only three fit in a width of 7.
+        let text = "日本語日本語";
+        let wrapped = wrap(text, 0, 7);
+        assert_eq!(row_texts(text, &wrapped), vec!["日本語", "日本語"]);
+    }
+
+    #[test]
+    fn test_cursor_column_counts_display_width() {
+        let text = "日本語";
+        let wrapped = wrap(text, 2, 10);
+        assert_eq!(wrapped.cursor_col, 4, "two wide glyphs are four columns");
+    }
+
+    #[test]
+    fn test_zero_width_is_treated_as_one_column() {
+        // Guards against a division-free infinite loop on a degenerate area.
+        let wrapped = wrap("abc", 0, 0);
+        assert_eq!(wrapped.rows.len(), 3);
+    }
+
+    #[test]
+    fn test_cursor_past_the_end_is_clamped() {
+        let wrapped = wrap("abc", 99, 10);
+        assert_eq!((wrapped.cursor_row, wrapped.cursor_col), (0, 3));
+    }
+
+    #[test]
+    fn test_run_of_spaces_does_not_lose_characters() {
+        let text = "a     b     c";
+        let wrapped = wrap(text, 0, 6);
+        assert_eq!(row_texts(text, &wrapped).concat(), text);
+    }
+}

--- a/src/tui/fuzzy.rs
+++ b/src/tui/fuzzy.rs
@@ -1,0 +1,100 @@
+//! Fuzzy matching helper shared by the TUI's entity picker and the composer's
+//! entity whisperer.
+//!
+//! Wraps `nucleo-matcher` so both call sites score candidates identically.
+
+use nucleo_matcher::{
+    Matcher, Utf32Str,
+    pattern::{AtomKind, CaseMatching, Normalization, Pattern},
+};
+
+/// Score every haystack against `query`, keeping only the ones that match.
+///
+/// Results are ordered by descending score; equal scores keep their original
+/// relative order, so the output is stable for a given input. An empty query
+/// matches everything, in the original order and with a score of 0.
+pub fn score_all(query: &str, haystacks: &[&str]) -> Vec<(usize, u32)> {
+    if query.is_empty() {
+        return (0..haystacks.len()).map(|i| (i, 0)).collect();
+    }
+
+    let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
+    let pattern = Pattern::new(query, CaseMatching::Ignore, Normalization::Smart, AtomKind::Fuzzy);
+
+    let mut scored: Vec<(usize, u32)> = haystacks
+        .iter()
+        .enumerate()
+        .filter_map(|(i, haystack)| {
+            let mut buf = Vec::new();
+            let haystack = Utf32Str::new(haystack, &mut buf);
+            pattern.score(haystack, &mut matcher).map(|score| (i, score))
+        })
+        .collect();
+
+    // Stable sort so equal scores keep input order, making results deterministic.
+    scored.sort_by_key(|&(_, score)| std::cmp::Reverse(score));
+    scored
+}
+
+/// Score every haystack and return just the matching indices, best first.
+pub fn match_indices(query: &str, haystacks: &[&str]) -> Vec<usize> {
+    score_all(query, haystacks).into_iter().map(|(i, _)| i).collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    const ENTITIES: [&str; 4] = ["Alice", "Alicia", "Bob", "Machine Learning"];
+
+    #[test]
+    fn test_empty_query_matches_everything_in_order() {
+        let matches = match_indices("", &ENTITIES);
+        assert_eq!(matches, vec![0, 1, 2, 3]);
+    }
+
+    #[test]
+    fn test_query_filters_out_non_matching_candidates() {
+        let matches = match_indices("ali", &ENTITIES);
+
+        assert!(matches.contains(&0), "Alice");
+        assert!(matches.contains(&1), "Alicia");
+        assert!(!matches.contains(&2), "Bob has no 'a'");
+        // Note "Machine Learning" *does* match: a-l-i appear in that order.
+        assert!(matches.contains(&3));
+    }
+
+    #[test]
+    fn test_exact_prefix_outranks_looser_match() {
+        let matches = match_indices("alice", &ENTITIES);
+        assert_eq!(matches.first(), Some(&0));
+    }
+
+    #[test]
+    fn test_matching_is_case_insensitive() {
+        assert_eq!(match_indices("BOB", &ENTITIES), vec![2]);
+    }
+
+    #[test]
+    fn test_non_contiguous_subsequence_matches() {
+        // Fuzzy, not substring: "ml" matches "Machine Learning".
+        assert_eq!(match_indices("ml", &ENTITIES), vec![3]);
+    }
+
+    #[test]
+    fn test_no_match_returns_empty() {
+        assert!(match_indices("zzzz", &ENTITIES).is_empty());
+    }
+
+    #[test]
+    fn test_equal_scores_keep_input_order() {
+        let haystacks = ["dup", "dup", "dup"];
+        assert_eq!(match_indices("dup", &haystacks), vec![0, 1, 2]);
+    }
+
+    #[test]
+    fn test_score_all_reports_descending_scores() {
+        let scored = score_all("ali", &ENTITIES);
+        assert!(scored.windows(2).all(|w| w[0].1 >= w[1].1));
+    }
+}

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -2,11 +2,11 @@
 //!
 //! Maps keyboard events to state mutations based on the current interaction mode.
 
-use nucleo_matcher::{Matcher, pattern::Pattern};
 use ratatui::crossterm::event::{KeyCode, KeyEvent};
 use tui_input::backend::crossterm::EventHandler;
 
 use super::App;
+use super::fuzzy;
 use super::state::Mode;
 
 /// Handle a key event and update app state.
@@ -164,32 +164,8 @@ fn handle_entity_picker_mode(app: &mut App, key: KeyEvent) {
             input.handle_event(&ratatui::crossterm::event::Event::Key(key));
 
             // Recompute fuzzy matches
-            let query = input.value();
-            if query.is_empty() {
-                *matches = (0..app.entities.len()).collect();
-            } else {
-                let mut matcher = Matcher::new(nucleo_matcher::Config::DEFAULT);
-                let pattern = Pattern::new(
-                    query,
-                    nucleo_matcher::pattern::CaseMatching::Ignore,
-                    nucleo_matcher::pattern::Normalization::Smart,
-                    nucleo_matcher::pattern::AtomKind::Fuzzy,
-                );
-
-                let mut scored: Vec<(usize, u32)> = app
-                    .entities
-                    .iter()
-                    .enumerate()
-                    .filter_map(|(i, entity)| {
-                        let mut buf = Vec::new();
-                        let haystack = nucleo_matcher::Utf32Str::new(&entity.canonical_name, &mut buf);
-                        pattern.score(haystack, &mut matcher).map(|score| (i, score))
-                    })
-                    .collect();
-
-                scored.sort_by(|a, b| b.1.cmp(&a.1));
-                *matches = scored.into_iter().map(|(i, _)| i).collect();
-            }
+            let names: Vec<&str> = app.entities.iter().map(|e| e.canonical_name.as_str()).collect();
+            *matches = fuzzy::match_indices(input.value(), &names);
             *selected = 0;
         }
     }

--- a/src/tui/input.rs
+++ b/src/tui/input.rs
@@ -335,6 +335,58 @@ mod tests {
     }
 
     #[test]
+    fn test_entity_picker_typing_narrows_matches() {
+        let entities = vec![make_entity("Sarah"), make_entity("Project"), make_entity("Sam")];
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
+        handle_key_event(&mut app, key_event(KeyCode::Char('/')));
+
+        handle_key_event(&mut app, key_event(KeyCode::Char('s')));
+
+        let Mode::EntityPicker { input, matches, .. } = &app.mode else {
+            panic!("expected the picker to stay open");
+        };
+        assert_eq!(input.value(), "s");
+        let matched: Vec<&str> = matches
+            .iter()
+            .map(|&i| app.entities[i].canonical_name.as_str())
+            .collect();
+        assert!(matched.contains(&"Sarah"), "{:?}", matched);
+        assert!(matched.contains(&"Sam"), "{:?}", matched);
+        assert!(!matched.contains(&"Project"), "{:?}", matched);
+    }
+
+    #[test]
+    fn test_entity_picker_backspace_widens_matches_again() {
+        let entities = vec![make_entity("Sarah"), make_entity("Project")];
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
+        handle_key_event(&mut app, key_event(KeyCode::Char('/')));
+        handle_key_event(&mut app, key_event(KeyCode::Char('s')));
+
+        handle_key_event(&mut app, key_event(KeyCode::Backspace));
+
+        let Mode::EntityPicker { input, matches, .. } = &app.mode else {
+            panic!("expected the picker to stay open");
+        };
+        assert_eq!(input.value(), "");
+        assert_eq!(matches.len(), 2, "an empty query offers every entity again");
+    }
+
+    #[test]
+    fn test_entity_picker_typing_resets_the_selection() {
+        let entities = vec![make_entity("Sarah"), make_entity("Sam")];
+        let mut app = App::new(vec![], entities, SortOrder::Ascending);
+        handle_key_event(&mut app, key_event(KeyCode::Char('/')));
+        handle_key_event(&mut app, key_event(KeyCode::Down));
+
+        handle_key_event(&mut app, key_event(KeyCode::Char('s')));
+
+        let Mode::EntityPicker { selected, .. } = &app.mode else {
+            panic!("expected the picker to stay open");
+        };
+        assert_eq!(*selected, 0, "a new query must not keep a stale highlight");
+    }
+
+    #[test]
     fn test_normal_mode_enter_opens_entity_detail() {
         let thoughts = vec![make_thought("Meeting with [Sarah]", 0)];
         let entities = vec![make_entity("Sarah")];

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -3,6 +3,7 @@
 //! Provides an interactive terminal UI for browsing thoughts with entity
 //! highlighting, fuzzy entity filtering, sort toggling, and entity description popups.
 
+pub mod fuzzy;
 pub mod input;
 pub mod state;
 pub mod ui;

--- a/src/tui/mod.rs
+++ b/src/tui/mod.rs
@@ -1,8 +1,10 @@
 //! TUI module for interactive thought viewer
 //!
 //! Provides an interactive terminal UI for browsing thoughts with entity
-//! highlighting, fuzzy entity filtering, sort toggling, and entity description popups.
+//! highlighting, fuzzy entity filtering, sort toggling, and entity description popups,
+//! plus the [`compose`] composer for entering new thoughts interactively.
 
+pub mod compose;
 pub mod fuzzy;
 pub mod input;
 pub mod state;

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -75,8 +75,11 @@ fn entity_color(entity: &str) -> Color {
     ansi_to_ratatui_color(ENTITY_COLORS[entity_color_index(entity)])
 }
 
-/// Build a styled Line from thought content, highlighting entity references.
-fn styled_content_line(content: &str, max_width: usize) -> Line<'static> {
+/// Split spans into the styled parts of `content`, highlighting entity references.
+///
+/// Entity references render as just their display text (the `[`, `]`, and any
+/// `(target)` are dropped), colored per [`entity_color`] and bolded.
+fn styled_spans(content: &str) -> Vec<Span<'static>> {
     let mut spans: Vec<Span<'static>> = Vec::new();
     let mut last_end = 0;
 
@@ -105,40 +108,32 @@ fn styled_content_line(content: &str, max_width: usize) -> Line<'static> {
         spans.push(Span::raw(content[last_end..].to_string()));
     }
 
-    // Truncate if needed
-    let line = Line::from(spans);
-    let total_width: usize = line.spans.iter().map(|s| s.content.len()).sum();
+    spans
+}
+
+/// Truncate a string to at most `max_chars` characters, respecting char boundaries.
+fn truncate_chars(text: &str, max_chars: usize) -> String {
+    match text.char_indices().nth(max_chars) {
+        Some((byte_idx, _)) => text[..byte_idx].to_string(),
+        None => text.to_string(),
+    }
+}
+
+/// Build a styled Line from thought content, highlighting entity references.
+///
+/// Shared with the interactive composer's live preview.
+pub(crate) fn styled_content_line(content: &str, max_width: usize) -> Line<'static> {
+    let spans = styled_spans(content);
+
+    // Truncate if needed. Widths are counted in characters, and slicing goes
+    // through `truncate_chars`, so multibyte content can never split a char.
+    let total_width: usize = spans.iter().map(|s| s.content.chars().count()).sum();
     if total_width > max_width && max_width > 3 {
-        // Rebuild with truncation — simplified approach: just use raw truncated string
-        let truncated = if content.len() > max_width - 1 {
-            format!("{}...", &content[..max_width.saturating_sub(3)])
-        } else {
-            content.to_string()
-        };
-        // Re-render the truncated content with styling
-        let mut spans2: Vec<Span<'static>> = Vec::new();
-        let mut last_end2 = 0;
-        for cap in ENTITY_PATTERN.captures_iter(&truncated) {
-            let full_match = cap.get(0).unwrap();
-            let display_text = cap[1].trim();
-            let target_entity = cap.get(2).map(|m| m.as_str().trim()).unwrap_or(display_text);
-            if full_match.start() > last_end2 {
-                spans2.push(Span::raw(truncated[last_end2..full_match.start()].to_string()));
-            }
-            let color = entity_color(target_entity);
-            spans2.push(Span::styled(
-                display_text.to_string(),
-                Style::default().fg(color).add_modifier(Modifier::BOLD),
-            ));
-            last_end2 = full_match.end();
-        }
-        if last_end2 < truncated.len() {
-            spans2.push(Span::raw(truncated[last_end2..].to_string()));
-        }
-        return Line::from(spans2);
+        let truncated = format!("{}...", truncate_chars(content, max_width - 3));
+        return Line::from(styled_spans(&truncated));
     }
 
-    line
+    Line::from(spans)
 }
 
 /// Render the full TUI frame.

--- a/src/tui/ui.rs
+++ b/src/tui/ui.rs
@@ -505,6 +505,35 @@ mod tests {
     }
 
     #[test]
+    fn test_styled_content_line_truncates_long_content() {
+        let line = styled_content_line("aaaaaaaaaaaaaaaaaaaaaaaaa", 10);
+
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.ends_with("..."), "{:?}", text);
+        assert!(text.chars().count() <= 10, "{:?}", text);
+    }
+
+    #[test]
+    fn test_styled_content_line_truncation_keeps_entity_styling() {
+        let line = styled_content_line("[Sarah] and a great deal of trailing text here", 12);
+
+        let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+        assert!(text.starts_with("Sarah"), "{:?}", text);
+        assert!(line.spans.iter().any(|s| s.style.fg.is_some()));
+    }
+
+    #[test]
+    fn test_styled_content_line_truncates_on_a_char_boundary() {
+        // Every char is multibyte, so a byte-index slice at the cut point would
+        // panic. Exercises each width around the boundary to catch off-by-ones.
+        for max_width in 4..14 {
+            let line = styled_content_line("ěščřžýáíéůúňť", max_width);
+            let text: String = line.spans.iter().map(|s| s.content.as_ref()).collect();
+            assert!(!text.is_empty(), "width {}", max_width);
+        }
+    }
+
+    #[test]
     fn test_styled_content_line_with_aliased_entity() {
         let line = styled_content_line("the [ML](machine-learning) course", 80);
         assert_eq!(line.spans.len(), 3);

--- a/tests/contract/test_add_command.rs
+++ b/tests/contract/test_add_command.rs
@@ -80,8 +80,36 @@ fn test_add_command_with_invalid_date() {
 
     assert_ne!(result.status, 0, "Command should fail with invalid date");
     assert!(
-        result.stderr.contains("Invalid date format"),
+        result.stderr.contains("Invalid date"),
         "Should report invalid date error. Got: {}",
         result.stderr
     );
+    assert!(
+        result.stderr.contains("YYYY-MM-DD"),
+        "Should list the accepted forms. Got: {}",
+        result.stderr
+    );
 }
+
+#[test]
+fn test_add_command_with_relative_date() {
+    let temp_db = setup_temp_db();
+
+    for date in ["today", "yesterday", "-3d", "-2w", "mon"] {
+        let result = run_wet_command(&["add", "Relative dated thought", "--date", date], Some(&temp_db));
+
+        assert_eq!(
+            result.status, 0,
+            "--date {} should be accepted. Got: {}",
+            date, result.stderr
+        );
+        assert!(
+            result.stdout.contains("Thought added"),
+            "Should confirm thought was added for --date {}. Got: {}",
+            date,
+            result.stdout
+        );
+    }
+}
+
+

--- a/tests/contract/test_add_command.rs
+++ b/tests/contract/test_add_command.rs
@@ -112,4 +112,25 @@ fn test_add_command_with_relative_date() {
     }
 }
 
+#[test]
+fn test_add_command_without_content_requires_a_terminal() {
+    let temp_db = setup_temp_db();
+    // Test processes get piped stdio, so the composer cannot start here. It must
+    // say so plainly rather than panicking or garbling the terminal.
+    let result = run_wet_command(&["add"], Some(&temp_db));
 
+    assert_ne!(result.status, 0, "Command should fail without a terminal");
+    assert!(
+        result.stderr.contains("terminal"),
+        "Should explain that a terminal is needed. Got: {}",
+        result.stderr
+    );
+}
+
+#[test]
+fn test_add_command_interactive_flag_conflicts_with_content() {
+    let temp_db = setup_temp_db();
+    let result = run_wet_command(&["add", "-i", "some content"], Some(&temp_db));
+
+    assert_ne!(result.status, 0, "-i and CONTENT are mutually exclusive");
+}

--- a/tests/integration/test_cli_execution.rs
+++ b/tests/integration/test_cli_execution.rs
@@ -9,7 +9,7 @@ fn test_add_execute_success() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("Test thought".to_string(), None, &db_path);
+    let result = add::execute(Some("Test thought".to_string()), None, &db_path);
     assert!(result.is_ok());
 }
 
@@ -18,7 +18,7 @@ fn test_add_execute_empty_fails() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("".to_string(), None, &db_path);
+    let result = add::execute(Some("".to_string()), None, &db_path);
     assert!(result.is_err());
 }
 
@@ -28,7 +28,7 @@ fn test_add_execute_too_long_fails() {
     let db_path = temp_dir.path().join("test.db");
 
     let long_content = "a".repeat(10_001);
-    let result = add::execute(long_content, None, &db_path);
+    let result = add::execute(Some(long_content), None, &db_path);
     assert!(result.is_err());
 }
 
@@ -47,8 +47,8 @@ fn test_notes_execute_with_notes() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add some thoughts first
-    add::execute("First thought".to_string(), None, &db_path).unwrap();
-    add::execute("Second thought".to_string(), None, &db_path).unwrap();
+    add::execute(Some("First thought".to_string()), None, &db_path).unwrap();
+    add::execute(Some("Second thought".to_string()), None, &db_path).unwrap();
 
     // List them
     let result = thoughts::execute(&db_path, None, ColorMode::Never, SortOrder::Descending);
@@ -61,9 +61,9 @@ fn test_notes_execute_with_entity_filter() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
-    add::execute("Call [John]".to_string(), None, &db_path).unwrap();
-    add::execute("Email [Sarah] the report".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Meeting with [Sarah]".to_string()), None, &db_path).unwrap();
+    add::execute(Some("Call [John]".to_string()), None, &db_path).unwrap();
+    add::execute(Some("Email [Sarah] the report".to_string()), None, &db_path).unwrap();
 
     // Filter by Sarah
     let result = thoughts::execute(&db_path, Some("Sarah"), ColorMode::Never, SortOrder::Descending);
@@ -89,9 +89,9 @@ fn test_entities_execute_with_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thoughts with entities
-    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
-    add::execute("Call [John]".to_string(), None, &db_path).unwrap();
-    add::execute("Email [Alice]".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Meeting with [Sarah]".to_string()), None, &db_path).unwrap();
+    add::execute(Some("Call [John]".to_string()), None, &db_path).unwrap();
+    add::execute(Some("Email [Alice]".to_string()), None, &db_path).unwrap();
 
     // List entities
     let result = wetware::cli::entities::execute(&db_path);
@@ -104,7 +104,7 @@ fn test_add_execute_with_date() {
     let db_path = temp_dir.path().join("test.db");
 
     let result = add::execute(
-        "Backdated thought".to_string(),
+        Some("Backdated thought".to_string()),
         Some("2024-03-15".to_string()),
         &db_path,
     );
@@ -116,7 +116,11 @@ fn test_add_execute_with_invalid_date() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    let result = add::execute("Bad date thought".to_string(), Some("not-a-date".to_string()), &db_path);
+    let result = add::execute(
+        Some("Bad date thought".to_string()),
+        Some("not-a-date".to_string()),
+        &db_path,
+    );
     assert!(result.is_err());
 }
 
@@ -125,7 +129,7 @@ fn test_delete_execute_success() {
     let temp_dir = TempDir::new().unwrap();
     let db_path = temp_dir.path().join("test.db");
 
-    add::execute("Thought to delete".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Thought to delete".to_string()), None, &db_path).unwrap();
 
     let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
     let thoughts = wetware::storage::thoughts_repository::ThoughtsRepository::list_all(&conn).unwrap();
@@ -146,7 +150,7 @@ fn test_delete_execute_nonexistent_id() {
     let db_path = temp_dir.path().join("test.db");
 
     // Initialize DB by adding and removing nothing - just need migrations to run
-    add::execute("Some thought".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Some thought".to_string()), None, &db_path).unwrap();
 
     let result = delete::execute(9999, &db_path);
     assert!(result.is_err());

--- a/tests/integration/test_entity_references.rs
+++ b/tests/integration/test_entity_references.rs
@@ -91,7 +91,7 @@ fn test_add_command_extracts_entities() {
 
     // Add a thought with entities
     let result = add::execute(
-        "Discussed [project-alpha] with [Sarah] and [John]".to_string(),
+        Some("Discussed [project-alpha] with [Sarah] and [John]".to_string()),
         None,
         &db_path,
     );
@@ -114,7 +114,7 @@ fn test_add_command_no_entities() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add a thought without entities
-    let result = add::execute("Regular thought without entities".to_string(), None, &db_path);
+    let result = add::execute(Some("Regular thought without entities".to_string()), None, &db_path);
     assert!(result.is_ok());
 
     // Verify no entities were created
@@ -264,7 +264,7 @@ fn test_add_command_bracket_mention_resolves_to_aliased_entity() {
     EntityAliasesRepository::add_alias(&conn, sarah_id, "sar").unwrap();
     drop(conn);
 
-    let result = add::execute("Talked to [sar] again".to_string(), None, &db_path);
+    let result = add::execute(Some("Talked to [sar] again".to_string()), None, &db_path);
     assert!(result.is_ok());
 
     let conn = wetware::storage::connection::get_connection(&db_path).unwrap();
@@ -295,7 +295,7 @@ fn test_add_command_ambiguous_alias_mention_skips_link_but_saves_thought() {
     drop(conn);
 
     // The whole add still succeeds even though "boss" is ambiguous.
-    let result = add::execute("Mentioned [boss] today".to_string(), None, &db_path);
+    let result = add::execute(Some("Mentioned [boss] today".to_string()), None, &db_path);
     assert!(result.is_ok());
 
     let conn = wetware::storage::connection::get_connection(&db_path).unwrap();

--- a/tests/integration/test_styled_output.rs
+++ b/tests/integration/test_styled_output.rs
@@ -10,7 +10,7 @@ fn test_styled_output_with_color_always() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Meeting with [Sarah]".to_string()), None, &db_path).unwrap();
 
     // Execute with colors always on (even though we're not in a TTY)
     let result = thoughts::execute(&db_path, None, ColorMode::Always, SortOrder::Descending);
@@ -23,7 +23,7 @@ fn test_styled_output_with_color_never() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Meeting with [Sarah]".to_string()), None, &db_path).unwrap();
 
     // Execute with colors disabled
     let result = thoughts::execute(&db_path, None, ColorMode::Never, SortOrder::Descending);
@@ -36,7 +36,7 @@ fn test_styled_output_with_color_auto() {
     let db_path = temp_dir.path().join("test.db");
 
     // Add thought with entity
-    add::execute("Meeting with [Sarah]".to_string(), None, &db_path).unwrap();
+    add::execute(Some("Meeting with [Sarah]".to_string()), None, &db_path).unwrap();
 
     // Execute with auto-detection (will be plain since tests aren't TTY)
     let result = thoughts::execute(&db_path, None, ColorMode::Auto, SortOrder::Descending);


### PR DESCRIPTION
## Why

`wet add "content" --date YYYY-MM-DD` was the only way to record a thought, and it gave no help with the two things that are hardest to get right while writing:

- **Entity syntax.** `[Entity]` / `[alias](Entity)` is documented in `--help` and `docs/`, but nothing at the point of entry showed which entities already existed. Since `resolve_or_create_entity` creates on any miss, a typo silently produced a near-duplicate to be cleaned up later with `wet entity merge`.
- **Dates.** Strict `YYYY-MM-DD` only, parsed inline and duplicated in `add.rs` and `edit.rs`. Backdating by two days meant looking up a calendar.

## What

`wet add -i` (or bare `wet add`) opens a composer:

```
┌Date───────────────────────────────────────┐
│yesterday → 2026-08-08 (Sat)               │
└───────────────────────────────────────────┘
┌Thought────────────────────────────────────┐
│met [ali                                   │
└───────────────────────────────────────────┘
┌Preview────────────────────────────────────┐
│met alicia about the launch   +new: Carol  │
└───────────────────────────────────────────┘
     ┌Entities──────────────────────────────┐
     │Alice          Team lead on the launch│
     │alicia → Alice Team lead on the launch│
     └──────────────────────────────────────┘
 Entities: [Name] · [your wording](Name) — type [ or ]( to search
 Date: YYYY-MM-DD · today · -3d · mon · Alt+←/→ shifts a day   Tab:field · Enter:save · Esc:quit
```

- **Whisperer.** `[` opens fuzzy completion over canonical names *and* aliases. `]( ` opens it again on the **link target**, so wording written by hand (`met [my boss](…`) still completes its entity — that was the one place a typo would otherwise create an unwanted entity. `(` elsewhere is ordinary prose and doesn't trigger it.
- **Accepting appends a space**, unless the following text already starts with whitespace or punctuation that should hug the reference (`[Alice].`, `[Alice]'s`). Content is trimmed on save so it never reaches storage.
- **Dates** resolve live. `Alt+←/→` shift by a day from either field, so a one-day correction costs no field round-trip.
- **Preview** colorizes the thought and marks mentions that would create a new entity.
- **Word wrap**: content is one logical line but wraps over as many rows as needed, growing to a cap then scrolling to keep the cursor visible.
- Saving keeps the composer open and reloads candidates, so entities just created are completable immediately.

Relative dates (`today`, `yesterday`, `-3d`, `-2w`, `-1m`, weekday names) now work for `wet add --date` and `wet edit --date` too, not just in the composer.

## Two fixes found along the way

- **`wet add` was not transactional.** Unlike `wet edit`, a failure while linking entities left the thought row behind. Sharing `thought_writer::create_thought` with the composer fixed it.
- **`styled_content_line` truncation sliced by byte offset** and would panic on a multibyte character at the boundary. Unreachable for the browser TUI; reachable the moment it's fed live keystrokes.

## Review notes

Five commits, each building and passing tests on its own — the three refactors are worth reading before the feature commit.

`unicode-width` becomes a direct dependency so wide glyphs wrap by display width rather than overflowing. It was already compiled in the tree via ratatui, so it adds no build time.

Wrapping is hand-rolled rather than `Paragraph::wrap` because the cursor must be placed at the wrapped position; deriving that from a second, independent wrap implementation would eventually disagree with what was drawn. Rendering and cursor placement now consume one `Wrapped` value.

## Verification

628 tests pass (up from 512), `cargo fmt` clean, no new clippy warnings. Beyond unit and render tests, the composer was driven end-to-end through a pty against the real binary: whisperer completion, alias→canonical resolution, `Alt`-arrow nudging, wrapping at 60 columns, and that no stray entity is created.

Docs: ADR 0015 with the alternatives turned down, a new `docs/flows/add-thought-interactive.md` (the repo had no add-thought flow doc), plus the `cli`/`tui`/`services` system docs and README.

🤖 Generated with [Claude Code](https://claude.com/claude-code)